### PR TITLE
adding quijote offset to fit_halo_bias

### DIFF
--- a/cmass/bias/fit_halo_bias.py
+++ b/cmass/bias/fit_halo_bias.py
@@ -44,8 +44,13 @@ def load_halo_histogram(cfg):
     N, Nm = cfg.nbody.N, cfg.fit.Nm
     mmin, mmax = cfg.fit.logMmin, cfg.fit.logMmax
 
-    # load quijote halos and compute histogram
+    # load quijote halos
     pos_h, mass, _, _ = load_quijote_halos(snapdir, z=cfg.nbody.zf)
+
+    # offset quijote halos by half a voxel (see issue #8)
+    pos_h = (pos_h + L/(2*N)) % L
+
+    # compute histogram
     posm = np.concatenate([pos_h, np.log10(mass)[:, None]], axis=1)
     h, edges = np.histogramdd(
         posm,


### PR DESCRIPTION
Quijote density fields are calculated at a slight offset ( - half a voxel) to place the corner voxel centered at (0, 0, 0).

To account for this in our halo bias fitting, we simply offset the halo positions by + half a voxel to line up correctly with the reported quijote density fields.

For more info, see issue #8.