### PR TITLE
Add YHe to CLASS transfer to deal with large values of Omega_b

### DIFF
--- a/cmass/conf/nbody/quijote_z0.yaml
+++ b/cmass/conf/nbody/quijote_z0.yaml
@@ -4,7 +4,7 @@ suite: quijote_z0
 # General parameters
 L: 1000           # Mpc/h
 N: 128            # meshgrid resolution
-lhid: 3           # latin hypercube id
+lhid: 0           # latin hypercube id
 matchIC: 2        # whether to match ICs to file (0 no, 1 yes, 2 quijote)
 Nvfield: 128      # velocity field resolution
 save_particles: false  # whether to save particle data

--- a/cmass/conf/nbody/quijote_z0.yaml
+++ b/cmass/conf/nbody/quijote_z0.yaml
@@ -4,7 +4,7 @@ suite: quijote_z0
 # General parameters
 L: 1000           # Mpc/h
 N: 128            # meshgrid resolution
-lhid: 0           # latin hypercube id
+lhid: 3           # latin hypercube id
 matchIC: 2        # whether to match ICs to file (0 no, 1 yes, 2 quijote)
 Nvfield: 128      # velocity field resolution
 save_particles: false  # whether to save particle data

--- a/cmass/nbody/borglpt.py
+++ b/cmass/nbody/borglpt.py
@@ -86,9 +86,9 @@ def run_density(wn, cpar, cfg):
     cpar.sigma8 = 0
     cpar.A_s = 2.3e-9
     k_max, k_per_decade = 10, 100
-    extra = {}
-    extra['YHe'] = '0.24'
-    cosmo = borg.cosmo.ClassCosmo(cpar, k_per_decade, k_max, extra=extra)
+    extra_class = {}
+    extra_class['YHe'] = '0.24'
+    cosmo = borg.cosmo.ClassCosmo(cpar, k_per_decade, k_max, extra=extra_class)
     cosmo.computeSigma8()
     cos = cosmo.getCosmology()
     cpar.A_s = (sigma8_true/cos['sigma_8'])**2*cpar.A_s
@@ -102,8 +102,10 @@ def run_density(wn, cpar, cfg):
     chain = borg.forward.ChainForwardModel(box)
     if nbody.transfer == 'CLASS':
         chain @= borg.forward.model_lib.M_PRIMORDIAL_AS(box)
-        chain @= borg.forward.model_lib.M_TRANSFER_CLASS(
+        transfer_class = borg.forward.model_lib.M_TRANSFER_CLASS(
             box, opts=dict(a_transfer=1.0))
+        transfer_class.setModelParams({"extra_class_arguments":extra_class})
+        chain @= transfer_class
     elif nbody.transfer == 'EH':
         chain @= borg.forward.model_lib.M_PRIMORDIAL(
             box, opts=dict(a_final=1.0))

--- a/cmass/nbody/borgpm.py
+++ b/cmass/nbody/borgpm.py
@@ -86,9 +86,9 @@ def run_density(wn, cpar, cfg):
     cpar.sigma8 = 0
     cpar.A_s = 2.3e-9
     k_max, k_per_decade = 10, 100
-    extra = {}
-    extra['YHe'] = '0.24'
-    cosmo = borg.cosmo.ClassCosmo(cpar, k_per_decade, k_max, extra=extra)
+    extra_class = {}
+    extra_class['YHe'] = '0.24'
+    cosmo = borg.cosmo.ClassCosmo(cpar, k_per_decade, k_max, extra=extra_class)
     cosmo.computeSigma8()
     cos = cosmo.getCosmology()
     cpar.A_s = (sigma8_true/cos['sigma_8'])**2*cpar.A_s
@@ -102,8 +102,10 @@ def run_density(wn, cpar, cfg):
     chain = borg.forward.ChainForwardModel(box)
     if nbody.transfer == 'CLASS':
         chain @= borg.forward.model_lib.M_PRIMORDIAL_AS(box)
-        chain @= borg.forward.model_lib.M_TRANSFER_CLASS(
+        transfer_class = borg.forward.model_lib.M_TRANSFER_CLASS(
             box, opts=dict(a_transfer=1.0))
+        transfer_class.setModelParams({"extra_class_arguments":extra_class})
+        chain @= transfer_class
     elif nbody.transfer == 'EH':
         chain @= borg.forward.model_lib.M_PRIMORDIAL(
             box, opts=dict(a_final=1.0))


### PR DESCRIPTION
This PR implements [Ludvig's suggestion](https://github.com/maho3/ltu-cmass/issues/19#issuecomment-2042091673) for how to solve the problematic large-Omega_b cases when running BORG with CLASS. Running with `lhid=15` (which was said to be problematic [here](https://github.com/maho3/ltu-cmass/issues/19#issue-2229971997)) no longer returns an error.