### PR TITLE
Fixing halo bias config

### DIFF
--- a/cmass/bias/rho_to_halo.py
+++ b/cmass/bias/rho_to_halo.py
@@ -148,6 +148,8 @@ def main(cfg: DictConfig) -> None:
     source_path = get_source_path(cfg, cfg.sim)
     bcfg = deepcopy(cfg)
     bcfg.nbody.suite = bcfg.bias.halo.base_suite
+    bcfg.nbody.L = bcfg.bias.halo.L
+    bcfg.nbody.N = bcfg.bias.halo.N
     bias_path = get_source_path(bcfg, cfg.sim)
 
     logging.info('Loading bias parameters...')

--- a/cmass/conf/bias/cic_hod.yaml
+++ b/cmass/conf/bias/cic_hod.yaml
@@ -1,7 +1,12 @@
 
 # halo biasing
 halo:
+  # where to find halo bias model
   base_suite: calib_1gpch_z0.5
+  L: 1000
+  N: 128
+
+  # how to interpolate halo velocities
   vel: "CIC"
 
 # galaxy biasing


### PR DESCRIPTION
In the recent integration of `hydra` config, I forgot to add `L` and `N` in the biasing configuration in order to make it easy to grab halo biasing models of smaller simulations and extend them to larger volumes. This is a small hotfix to add this configuration, which most people can simply take as a default.