### PR TITLE
removal of all references to snapshot_mode

### DIFF
--- a/cmass/bias/rho_to_halo.py
+++ b/cmass/bias/rho_to_halo.py
@@ -347,28 +347,16 @@ def main(cfg: DictConfig) -> None:
     if cfg.bias.halo.model == 'CHARM':
         rho_transfer = load_transfer(source_path)
 
-    if cfg.nbody.snapshot_mode:
-        for i, a in enumerate(cfg.nbody.asave):
-            logging.info(f'Running snapshot {i} at a={a:.6f}...')
-            rho, fvel, ppos, pvel = load_snapshot(source_path, a)
-
-            # Apply bias model
-            hpos, hvel, hmass = run_snapshot(
-                rho, fvel, cfg, rho_transfer, ppos, pvel)
-
-            logging.info(f'Saving halo catalog to {source_path}')
-            save_snapshot(source_path, a, hpos, hvel, hmass)
-    else:
-        # Load single snapshot
-        logging.info('Loading single snapshot...')
-        rho, fvel, ppos, pvel = load_snapshot(source_path, cfg.nbody.af)
+    for i, a in enumerate(cfg.nbody.asave):
+        logging.info(f'Running snapshot {i} at a={a:.6f}...')
+        rho, fvel, ppos, pvel = load_snapshot(source_path, a)
 
         # Apply bias model
         hpos, hvel, hmass = run_snapshot(
             rho, fvel, cfg, rho_transfer, ppos, pvel)
 
         logging.info(f'Saving halo catalog to {source_path}')
-        save_snapshot(source_path, cfg.nbody.af, hpos, hvel, hmass)
+        save_snapshot(source_path, a, hpos, hvel, hmass)
 
     save_cfg(source_path, cfg, field='bias')
     logging.info('Done!')

--- a/cmass/conf/nbody/1gpch.yaml
+++ b/cmass/conf/nbody/1gpch.yaml
@@ -13,8 +13,6 @@ save_transfer: true    # whether to save transfer fn densities (for CHARM)
 zi: 20            # initial redshift
 zf: 0.5           # final redshift
 
-# whether to save multiple snapshots and use lightcone extrapolation
-snapshot_mode: false
 # increasing snapshot scale factors to save (evenly spaced in a)
 asave: []
 

--- a/cmass/conf/nbody/2gpch.yaml
+++ b/cmass/conf/nbody/2gpch.yaml
@@ -13,8 +13,6 @@ save_transfer: true    # whether to save transfer fn densities (for CHARM)
 zi: 20            # initial redshift
 zf: 0.5           # final redshift
 
-# whether to save multiple snapshots and use lightcone extrapolation
-snapshot_mode: false
 # increasing snapshot scale factors to save (evenly spaced in a)
 asave: []
 

--- a/cmass/conf/nbody/2gpch_0704.yaml
+++ b/cmass/conf/nbody/2gpch_0704.yaml
@@ -13,8 +13,6 @@ save_transfer: true    # whether to save transfer fn densities
 zi: 20            # initial redshift
 zf: 0.5           # final redshift
 
-# whether to save multiple snapshots and use lightcone extrapolation
-snapshot_mode: false
 # increasing snapshot scale factors to save (evenly spaced in a)
 asave: []
 

--- a/cmass/conf/nbody/3gpch.yaml
+++ b/cmass/conf/nbody/3gpch.yaml
@@ -13,8 +13,6 @@ save_transfer: true    # whether to save transfer fn densities (for CHARM)
 zi: 20            # initial redshift
 zf: 0.5           # final redshift
 
-# whether to save multiple snapshots and use lightcone extrapolation
-snapshot_mode: false
 # increasing snapshot scale factors to save (evenly spaced in a)
 asave: []
 

--- a/cmass/conf/nbody/3gpch_nolc_B1.yaml
+++ b/cmass/conf/nbody/3gpch_nolc_B1.yaml
@@ -13,8 +13,6 @@ save_transfer: true    # whether to save transfer fn densities
 zi: 10            # initial redshift
 zf: 0.5           # final redshift
 
-# whether to save multiple snapshots and use lightcone extrapolation
-snapshot_mode: false
 # increasing snapshot scale factors to save (evenly spaced in a)
 asave: []
 

--- a/cmass/conf/nbody/abacus.yaml
+++ b/cmass/conf/nbody/abacus.yaml
@@ -13,8 +13,6 @@ save_transfer: false    # whether to save z=99 ICs (for CHARM bias model)
 zi: 20            # initial redshift (for grav solver)
 zf: 0.5           # final redshift
 
-# whether to save multiple snapshots and use lightcone extrapolation
-snapshot_mode: false
 # increasing snapshot scale factors to save (evenly spaced in a)
 asave: []
 

--- a/cmass/conf/nbody/mtng.yaml
+++ b/cmass/conf/nbody/mtng.yaml
@@ -13,8 +13,6 @@ save_transfer: false    # whether to save z=99 ICs (for CHARM bias model)
 zi: 20            # initial redshift (for grav solver)
 zf: 0.5           # final redshift
 
-# whether to save multiple snapshots and use lightcone extrapolation
-snapshot_mode: false
 # increasing snapshot scale factors to save (evenly spaced in a)
 asave: []
 

--- a/cmass/conf/nbody/quijote.yaml
+++ b/cmass/conf/nbody/quijote.yaml
@@ -13,8 +13,6 @@ save_transfer: false    # whether to save z=99 ICs (for CHARM bias model)
 zi: 20            # initial redshift (for grav solver)
 zf: 0.5           # final redshift
 
-# whether to save multiple snapshots and use lightcone extrapolation
-snapshot_mode: false
 # increasing snapshot scale factors to save (evenly spaced in a)
 asave: []
 

--- a/cmass/conf/nbody/quijotelike.yaml
+++ b/cmass/conf/nbody/quijotelike.yaml
@@ -13,8 +13,6 @@ save_transfer: True    # whether to save z=99 ICs (for CHARM bias model)
 zi: 20            # initial redshift (for grav solver)
 zf: 0.5           # final redshift
 
-# whether to save multiple snapshots and use lightcone extrapolation
-snapshot_mode: false
 # increasing snapshot scale factors to save (evenly spaced in a)
 asave: []
 

--- a/cmass/nbody/borgpm_lc.py
+++ b/cmass/nbody/borgpm_lc.py
@@ -110,11 +110,6 @@ def main(cfg: DictConfig) -> None:
         hydra.core.hydra_config.HydraConfig.get().runtime.output_dir)
     logging.info('Running with config:\n' + OmegaConf.to_yaml(cfg))
 
-    # Check if we're in snapshot mode
-    if not (hasattr(cfg.nbody, 'snapshot_mode') and cfg.nbody.snapshot_mode):
-        raise ValueError("snapshot_mode config is false, but borgpm_lc"
-                         "is only for snapshot mode.")
-
     # Output directory
     outdir = get_source_path(
         cfg.meta.wdir, cfg.nbody.suite, "borgpm",

--- a/cmass/nbody/tools.py
+++ b/cmass/nbody/tools.py
@@ -34,7 +34,7 @@ def parse_nbody_config(cfg):
         nbody.matchIC = nbody.matchIC > 0  # whether to match ICs to file
 
         # default asave
-        if not (hasattr(nbody, 'snapshot_mode') and nbody.snapshot_mode):
+        if ('asave' not in nbody) or (len(nbody.asave) == 0):
             nbody.asave = [nbody.af]
 
         # load cosmology

--- a/cmass/survey/ngc_lightcone.py
+++ b/cmass/survey/ngc_lightcone.py
@@ -94,11 +94,6 @@ def main(cfg: DictConfig) -> None:
     hod_seed = cfg.bias.hod.seed  # for indexing different hod realizations
     aug_seed = cfg.survey.aug_seed  # for rotating and shuffling
 
-    # Check that we are in snapshot_mode
-    if not (hasattr(cfg.nbody, 'snapshot_mode') and cfg.nbody.snapshot_mode):
-        raise ValueError('snapshot_mode config is false, but ngc_lightcone'
-                         ' is only for snapshot mode.')
-
     # Load mask
     logging.info(f'Loading mask from {cfg.survey.boss_dir}')
     maskobs = lc.Mask(boss_dir=cfg.survey.boss_dir, veto=True)

--- a/cmass/survey/ngc_selection.py
+++ b/cmass/survey/ngc_selection.py
@@ -172,11 +172,6 @@ def main(cfg: DictConfig) -> None:
     hod_seed = cfg.bias.hod.seed  # for indexing different hod realizations
     aug_seed = cfg.survey.aug_seed  # for rotating and shuffling
 
-    # Check that we are not in snapshot_mode
-    if hasattr(cfg.nbody, 'snapshot_mode') and cfg.nbody.snapshot_mode:
-        raise ValueError('snapshot_mode config is true, but ngc_selection'
-                         ' is only for non snapshot mode.')
-
     # Load galaxies
     pos, vel, _ = load_galaxies(source_path, cfg.nbody.af, hod_seed)
 

--- a/cmass/survey/tools.py
+++ b/cmass/survey/tools.py
@@ -139,7 +139,7 @@ def random_rotate_translate(xyz, L, vel=None, seed=0):
     Args:
     - xyz (np.ndarray): (N, 3) array of positions in the cube.
     - L (float): side length of the cube.
-    - vel (np.ndarray, optional): (N, 3) array of velocities. 
+    - vel (np.ndarray, optional): (N, 3) array of velocities.
     - seed (int): random seed for reproducibility. If 0, no transformation
         is applied.
     """
@@ -186,8 +186,8 @@ def BOSS_angular(ra, dec, wdir='./data'):
 
 
 def BOSS_veto(ra, dec, verbose=False, wdir='./data'):
-    ''' given RA and Dec, find the objects that fall within one of the veto 
-    masks of BOSS. At the moment it checks through the veto masks one by one.  
+    ''' given RA and Dec, find the objects that fall within one of the veto
+    masks of BOSS. At the moment it checks through the veto masks one by one.
     '''
     in_veto = np.zeros(len(ra)).astype(bool)
     fvetos = [
@@ -273,6 +273,11 @@ def load_galaxies(source_dir, a, seed):
     filepath = join(source_dir, 'galaxies', f'hod{seed:03}.h5')
     with h5py.File(filepath, 'r') as f:
         key = f'{a:.6f}'
+        if key not in f:
+            raise ValueError(
+                f'Snapshot a={key} not found in {filepath}. Ensure you are '
+                'using the appropriate single-snapshot ngc_selection or the '
+                'multi-snapshot ngc_lightcone.')
         pos = f[key]['pos'][...]
         vel = f[key]['vel'][...]
         hostid = f[key]['hostid'][...]


### PR DESCRIPTION
Since ngc_lighcone can be used with/without snapshot mode, we don't need to specify it manually. I've also included a warning in `load_galaxies` in case people can't figure out why a certain snapshot isn't there.