### PR TITLE
get_*_pk functions now return both k's and pk's

### DIFF
--- a/cmass/nbody/pinocchio.py
+++ b/cmass/nbody/pinocchio.py
@@ -79,11 +79,11 @@ def generate_pk_file(cfg, outdir):
     k = np.logspace(np.log10(kmin), np.log10(kmax), 2*cfg.nbody.N)
 
     if cfg.nbody.transfer.upper() == 'CAMB':
-        pk = get_camb_pk(k, *cfg.nbody.cosmo)
+        k, pk = get_camb_pk(k, *cfg.nbody.cosmo)
     elif cfg.nbody.transfer.upper() == 'CLASS':
-        pk = get_class_pk(k, *cfg.nbody.cosmo)
+        k, pk = get_class_pk(k, *cfg.nbody.cosmo)
     elif cfg.nbody.transfer.upper() == 'SYREN':
-        pk = get_syren_pk(k, *cfg.nbody.cosmo)
+        k, pk = get_syren_pk(k, *cfg.nbody.cosmo)
     else:
         raise NotImplementedError(
             f"Unknown power spectrum method: {cfg.nbody.power_spectrum}")

--- a/cmass/nbody/tools.py
+++ b/cmass/nbody/tools.py
@@ -207,18 +207,19 @@ def get_camb_pk(k, omega_m, omega_b, h, n_s, sigma8, z=0.):
     )
     As_fid = 2.0e-9
     pars.InitPower.set_params(As=As_fid, ns=n_s, r=0)
-    pars.set_matter_power(redshifts=[z], kmax=k[-1])
+    pars.set_matter_power(redshifts=[0.0], kmax=k[-1])
     pars.NonLinear = camb.model.NonLinear_none
     results = camb.get_results(pars)
     sigma8_camb = results.get_sigma8()[0]
     As_new = (sigma8 / sigma8_camb) ** 2 * As_fid
     pars.InitPower.set_params(As=As_new, ns=n_s, r=0)
+    pars.set_matter_power(redshifts=[z], kmax=k[-1])
     results = camb.get_results(pars)
-    _, _, pk_camb = results.get_matter_power_spectrum(
-        minkh=k.min(), maxkh=k.max(), npoints=len(k))
+    kh, _, pk_camb = results.get_matter_power_spectrum(
+        minkh=k.min(), maxkh=k.max(), npoints=len(k))  # returns log-spaced k's
     pk_camb = pk_camb[0, :]
 
-    return pk_camb
+    return kh, pk_camb
 
 
 def class_compute(class_params):
@@ -292,7 +293,7 @@ def get_class_pk(k, omega_m, omega_b, h, n_s, sigma8):
     cosmo.struct_cleanup()
     cosmo.empty()
 
-    return plin_class
+    return k, plin_class
 
 
 def get_syren_pk(k, omega_m, omega_b, h, n_s, sigma8):
@@ -301,7 +302,7 @@ def get_syren_pk(k, omega_m, omega_b, h, n_s, sigma8):
             "syren transfer function requested, but syren not installed. "
             "See ltu-cmass installation instructions."
         )
-    return symbolic_pofk.linear.plin_emulated(
+    return k, symbolic_pofk.linear.plin_emulated(
         k, sigma8, omega_m, omega_b, h, n_s,
         emulator='fiducial', extrapolate=True
     )


### PR DESCRIPTION
This is because the `get_camb_pk` inner workings can only output log-spaced k's,  such that if you give it any other k's the output will be incorrect.