### PR TITLE
Get FastPM working on SLURM machines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,4 @@ timing_stats*
 sbi-logs
 matts_tests
 .vscode
+slurm_hostfile

--- a/cmass/nbody/fastpm.py
+++ b/cmass/nbody/fastpm.py
@@ -270,6 +270,10 @@ def main(cfg: DictConfig) -> None:
     # TODO: add a way to append particles to the existing nbody.h5 file
     save_cfg(outdir, cfg)
 
+    # clean up slurm hostfile if it exists
+    if os.path.isfile('slurm_hostfile'):
+        os.remove('slurm_hostfile')
+
     logging.info("Done!")
 
 


### PR DESCRIPTION
This adds a small fix to allow fastpm.py to parse the SLURM nodelists and pass them to mpirun.