### PR TITLE
Move executables to global.yaml

### DIFF
--- a/cmass/conf/global.yaml
+++ b/cmass/conf/global.yaml
@@ -11,8 +11,13 @@ hydra:
 meta:
   wdir: "/home/mattho/git/ltu-cmass/data"
   # wdir: "/data101/bartlett/ili/cmass/"
+  # wdir: "/anvil/scratch/x-mho1/cmass-ili"
   logdir: "${meta.wdir}/logs/"
   cosmofile: "./params/latin_hypercube_params.txt"    # for quijote-like
   # cosmofile: "./params/big_sobol_params.txt"        # for big_sobol-like
   # cosmofile: "./params/abacus_cosmologies.txt"      # for abacus-like
   # cosmofile: "./params/mtng_cosmologies.txt"        # for mtng-like
+
+  # executables
+  fastpm_exec: /home/mattho/git/fastpm/src/fastpm
+  pinocchio_exec: /home/mattho/git/Pinocchio/src/pinocchio.x

--- a/cmass/conf/nbody/1gpch.yaml
+++ b/cmass/conf/nbody/1gpch.yaml
@@ -32,4 +32,3 @@ COLA: true        # whether to use COLA
 
 # pinocchio only
 mass_function: Watson_2013  # which output HMF to use
-pinocchio_exec: /home/mattho/git/Pinocchio/src/pinocchio.x

--- a/cmass/conf/nbody/2gpch.yaml
+++ b/cmass/conf/nbody/2gpch.yaml
@@ -32,4 +32,3 @@ COLA: true        # whether to use COLA
 
 # pinocchio only
 mass_function: Watson_2013  # which output HMF to use
-pinocchio_exec: /home/mattho/git/Pinocchio/src/pinocchio.x

--- a/cmass/conf/nbody/2gpch_0704.yaml
+++ b/cmass/conf/nbody/2gpch_0704.yaml
@@ -31,4 +31,3 @@ COLA: true        # whether to use COLA
 
 # pinocchio only
 mass_function: Watson_2013  # which output HMF to use
-pinocchio_exec: /home/mattho/git/Pinocchio/src/pinocchio.x

--- a/cmass/conf/nbody/3gpch.yaml
+++ b/cmass/conf/nbody/3gpch.yaml
@@ -32,4 +32,3 @@ COLA: true        # whether to use COLA
 
 # pinocchio only
 mass_function: Watson_2013  # which output HMF to use
-pinocchio_exec: /home/mattho/git/Pinocchio/src/pinocchio.x

--- a/cmass/conf/nbody/3gpch_nolc_B1.yaml
+++ b/cmass/conf/nbody/3gpch_nolc_B1.yaml
@@ -31,4 +31,3 @@ COLA: true        # whether to use COLA
 
 # pinocchio only
 mass_function: Watson_2013  # which output HMF to use
-pinocchio_exec: /home/mattho/git/Pinocchio/src/pinocchio.x

--- a/cmass/conf/nbody/abacus.yaml
+++ b/cmass/conf/nbody/abacus.yaml
@@ -33,4 +33,3 @@ COLA: true        # whether to use COLA
 
 # pinocchio only
 mass_function: Watson_2013  # which output HMF to use
-pinocchio_exec: /home/mattho/git/Pinocchio/src/pinocchio.x

--- a/cmass/conf/nbody/fastpm.yaml
+++ b/cmass/conf/nbody/fastpm.yaml
@@ -31,4 +31,3 @@ COLA: true        # whether to use COLA
 
 # pinocchio only
 mass_function: Watson_2013  # which output HMF to use
-pinocchio_exec: /home/mattho/git/Pinocchio/src/pinocchio.x

--- a/cmass/conf/nbody/fastpm.yaml
+++ b/cmass/conf/nbody/fastpm.yaml
@@ -32,6 +32,3 @@ COLA: true        # whether to use COLA
 # pinocchio only
 mass_function: Watson_2013  # which output HMF to use
 pinocchio_exec: /home/mattho/git/Pinocchio/src/pinocchio.x
-
-# fastpm only
-fastpm_exec: /home/mattho/git/fastpm/src/fastpm

--- a/cmass/conf/nbody/mtng.yaml
+++ b/cmass/conf/nbody/mtng.yaml
@@ -33,4 +33,3 @@ COLA: true        # whether to use COLA
 
 # pinocchio only
 mass_function: Watson_2013  # which output HMF to use
-pinocchio_exec: /home/mattho/git/Pinocchio/src/pinocchio.x

--- a/cmass/conf/nbody/pinocchio.yaml
+++ b/cmass/conf/nbody/pinocchio.yaml
@@ -28,4 +28,3 @@ COLA: true        # whether to use COLA
 
 # pinocchio only
 mass_function: Watson_2013  # which output HMF to use
-pinocchio_exec: /home/mattho/git/Pinocchio/src/pinocchio.x

--- a/cmass/conf/nbody/quijote.yaml
+++ b/cmass/conf/nbody/quijote.yaml
@@ -33,4 +33,3 @@ COLA: true        # whether to use COLA
 
 # pinocchio only
 mass_function: Watson_2013  # which output HMF to use
-pinocchio_exec: /home/mattho/git/Pinocchio/src/pinocchio.x

--- a/cmass/conf/nbody/quijotelike.yaml
+++ b/cmass/conf/nbody/quijotelike.yaml
@@ -33,6 +33,3 @@ COLA: true        # whether to use COLA
 # pinocchio only
 mass_function: Watson_2013  # which output HMF to use
 pinocchio_exec: /home/mattho/git/Pinocchio/src/pinocchio.x
-
-# fastpm only
-fastpm_exec: /home/mattho/git/fastpm/src/fastpm

--- a/cmass/conf/nbody/quijotelike.yaml
+++ b/cmass/conf/nbody/quijotelike.yaml
@@ -32,4 +32,3 @@ COLA: true        # whether to use COLA
 
 # pinocchio only
 mass_function: Watson_2013  # which output HMF to use
-pinocchio_exec: /home/mattho/git/Pinocchio/src/pinocchio.x

--- a/cmass/conf/nbody/testsmall.yaml
+++ b/cmass/conf/nbody/testsmall.yaml
@@ -32,4 +32,3 @@ COLA: true        # whether to use COLA
 
 # pinocchio only
 mass_function: Watson_2013  # which output HMF to use
-pinocchio_exec: /home/mattho/git/Pinocchio/src/pinocchio.x

--- a/cmass/nbody/fastpm.py
+++ b/cmass/nbody/fastpm.py
@@ -144,7 +144,7 @@ def run_density(cfg, outdir):
     #  Run FastPM
     param_file = join(outdir, "parameter_file.lua")
     command = f'mpirun -n {max_divisible_cores} {mpi_args} '
-    command += f'{cfg.nbody.fastpm_exec} {param_file}'
+    command += f'{cfg.meta.fastpm_exec} {param_file}'
     env = os.environ.copy()
     env["OMP_NUM_THREADS"] = "1"
     _ = subprocess.run(command, shell=True, check=True, env=env)

--- a/cmass/nbody/pinocchio.py
+++ b/cmass/nbody/pinocchio.py
@@ -193,7 +193,7 @@ def run_density(cfg, outdir):
     # Run pinoccio
     cwd = os.getcwd()
     os.chdir(outdir)
-    os.system(f'{cfg.nbody.pinocchio_exec} parameter_file')
+    os.system(f'{cfg.meta.pinocchio_exec} parameter_file')
     os.chdir(cwd)
 
     # Load the data

--- a/docs/options/FASTPM.md
+++ b/docs/options/FASTPM.md
@@ -28,8 +28,8 @@ make
 ./src/fastpm --help
 ```
 
-Then, change your `nbody` configuration to the path of your FastPM executable:
+Then, change your `global.meta` configuration to the path of your FastPM executable:
 ```yaml
 fastpm_exec: /path/to/git/fastpm/src/fastpm
 ```
-An example of this is in [fastpm.yaml](../../cmass/conf/nbody/fastpm.yaml).
+An example of this is in [global.yaml](../../cmass/conf/global.yaml).

--- a/docs/options/PINOCCHIO.md
+++ b/docs/options/PINOCCHIO.md
@@ -25,7 +25,7 @@ endif
 ```
 Also change the `SYSTYPE` argument to be `"infinity"` and ensure the "-DWHITENOISE" option is enabled. Building with `make clean; make` should then work. 
 
-Lastly, in [your nbody configuration file](../../cmass/conf/nbody/pinocchio.yaml) you need to specify the absolute path to your Pinocchio executable. This is the `pinnochio.x` file in the `src` directory of Pinocchio, generated during the `make`. For example, mine is:
+Lastly, in [your global configuration file](../../cmass/conf/global.yaml) you need to specify the absolute path to your Pinocchio executable. This is the `pinnochio.x` file in the `src` directory of Pinocchio, generated during the `make`. For example, mine is:
 ```yaml
 pinocchio_exec: /home/mattho/git/Pinocchio/src/pinocchio.x
 ```


### PR DESCRIPTION
Previously, the configurations for the fastpm and pinocchio scripts required specification of an executable path, i.e. `fastpm_exec` or `pinocchio_exec`. When moving to other machines, it is a pain to have to turn off the tracking of all these config files every time.

So, I moved the `fastpm_exec` and `pinocchio_exec` to the `global.yaml` file, which is already being set to be untracked due to the `wdir` specification. Then, people will only need to edit this one file with custom paths when they get set up on their new machines.