### PR TITLE
Simon/self consistent tests

### DIFF
--- a/cmass/conf/diag/default.yaml
+++ b/cmass/conf/diag/default.yaml
@@ -6,4 +6,3 @@ threads: 16
 
 # number of lhid to include for the visualization
 n_seeds: 1
-lhid_start: 0

--- a/cmass/conf/diag/default.yaml
+++ b/cmass/conf/diag/default.yaml
@@ -1,6 +1,9 @@
-
 # whether to calculate diagnostics from scratch, if already saved
 from_scratch: true
 
 # number of threads for P(k) computation
 threads: 16
+
+# number of lhid to include for the visualization
+n_seeds: 1
+lhid_start: 0

--- a/cmass/conf/diag/default.yaml
+++ b/cmass/conf/diag/default.yaml
@@ -6,3 +6,8 @@ threads: 16
 
 # number of lhid to include for the visualization
 n_seeds: 1
+
+# where to find the diag files for a comparison
+make_comparison: false
+compare_suite: quijote
+compare_sim: nbody

--- a/cmass/conf/global.yaml
+++ b/cmass/conf/global.yaml
@@ -11,6 +11,7 @@ hydra:
 meta:
   wdir: "/home/mattho/git/ltu-cmass/data"
   # wdir: "/data101/bartlett/ili/cmass/"
+  odir: "${meta.wdir}"
   logdir: "${meta.wdir}/logs/"
   cosmofile: "./params/latin_hypercube_params.txt"    # for quijote-like
   # cosmofile: "./params/big_sobol_params.txt"        # for big_sobol-like

--- a/cmass/diagnostics/summ.py
+++ b/cmass/diagnostics/summ.py
@@ -75,9 +75,15 @@ def halo_summ(source_path, L, N, h, z, threads=16, from_scratch=True, out_dir=No
         with h5py.File(outpath, 'w') as o:
             for a in alist:
                 # Load
+                # FIXME: Add mass cut 10**13 for pinocchio
                 hpos = f[a]['pos'][...].astype(np.float32)
                 hvel = f[a]['vel'][...].astype(np.float32)
                 hmass = f[a]['mass'][...].astype(np.float32)
+
+                mask = np.where(hmass >= 13.)
+                hpos = hpos[mask]
+                hvel = hvel[mask]
+                hmass = hmass[mask]
 
                 # measure halo Pk in comoving space
                 delta = MA(hpos, L, N, MAS='NGP')

--- a/cmass/diagnostics/summ.py
+++ b/cmass/diagnostics/summ.py
@@ -75,9 +75,9 @@ def halo_summ(source_path, L, N, h, z, threads=16, from_scratch=True, out_dir=No
         with h5py.File(outpath, 'w') as o:
             for a in alist:
                 # Load
-                hpos = f[a]['pos'][...]
-                hvel = f[a]['vel'][...]
-                hmass = f[a]['mass'][...]
+                hpos = f[a]['pos'][...].astype(np.float32)
+                hvel = f[a]['vel'][...].astype(np.float32)
+                hmass = f[a]['mass'][...].astype(np.float32)
 
                 # measure halo Pk in comoving space
                 delta = MA(hpos, L, N, MAS='NGP')

--- a/cmass/diagnostics/vis_summ.py
+++ b/cmass/diagnostics/vis_summ.py
@@ -253,8 +253,8 @@ def main(cfg: DictConfig) -> None:
         )
 
         compare_paths = [get_source_path(
-            wdir, 'quijotelike', 'fastpm',
-            L, N, lhid=lhids
+            wdir, 'quijote', 'nbody',
+            L, 128, lhid=lhids
         )]
 
         source_path = [source_path]

--- a/cmass/diagnostics/vis_summ.py
+++ b/cmass/diagnostics/vis_summ.py
@@ -24,7 +24,7 @@ def plot_halo_sum(source_path, L, N, h, z, from_scratch=True, out_dir=None):
 
     # check if diagnostics is computed
     source_file = join(source_path, 'diag', 'halos.h5')
-    if os.path.isfile(source_path):
+    if os.path.isfile(source_file):
         logging.info('Halo diagnostics already computed. Proceeding with visualisation.')
     else:
         logging.error(f'{source_file} with halo diagnostics not found.')

--- a/cmass/diagnostics/vis_summ.py
+++ b/cmass/diagnostics/vis_summ.py
@@ -6,6 +6,7 @@ Can be also used to compare between different runs.
 
 import os
 
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 import logging
@@ -18,46 +19,106 @@ from ..utils import get_source_path, timing_decorator
 from ..nbody.tools import parse_nbody_config
 
 
-def plot_halo_sum(source_path, L, N, h, z, from_scratch=True, out_dir=None):
-    if out_dir is None:
-        out_dir = source_path
-
-    # check if diagnostics is computed
-    source_file = join(source_path, 'diag', 'halos.h5')
+def check_diagnostics_exist(path, diag_dir, diag_file):
+    source_file = join(path, 'diag', 'halos.h5')
     if os.path.isfile(source_file):
         logging.info('Halo diagnostics already computed. Proceeding with visualisation.')
+        return True
     else:
         logging.error(f'{source_file} with halo diagnostics not found.')
         return False
 
+
+def extract_halo_diagnostics(file_path, group):
+    with h5py.File(file_path, 'r') as f:
+        # Load
+        k = f[group]['Pk_k'][...]
+        Pk = f[group]['Pk'][...]
+        kz = f[group]['zPk_k'][...]
+        Pkz = f[group]['zPk'][...]
+        mass_bins = f[group]['mass_bins'][...]
+        mass_hist = f[group]['mass_hist'][...]
+
+        return k, Pk, kz, Pkz, mass_bins, mass_hist
+
+
+def plot_halo_sum(source_path, L, N, out_dir, lhids):
+    # TODO: Implement use of mpl style files
+    # plt.style.use('/home/sding/PhD/codes/ltu-cmass/cmass/conf/diag/aa_one_column.mplstyle')
+
+    if len(source_path) == 1:
+        source_path = [source_path]
+        lhids = [lhids]
+
+    # check if diagnostics is computed
+    all_diagnostics_exist = np.all([check_diagnostics_exist(path, 'diag', 'halos.h5')
+                                    for path in source_path])
+    if not all_diagnostics_exist:
+        return False
+
+    source_files = [join(path, 'diag', 'halos.h5') for path in source_path]
     # check for file keys
-    with h5py.File(source_file, 'r') as f:
+    with h5py.File(source_files[0], 'r') as f:
         alist = list(f.keys())
 
     outpath = join(out_dir, 'diag')
     os.makedirs(outpath, exist_ok=True)
     logging.info(f'Saving halo diagnostics to {outpath}')
 
-    # compute diagnostics and save
-    with h5py.File(source_file, 'r') as f:
-        for a in alist:
-            out_file = join(outpath, f'halo_summ_group{a}.svg')
-            # Load
-            k = f[a]['Pk_k'][...]
-            Pk = f[a]['Pk'][...]
-            kz = f[a]['zPk_k'][...]
-            Pkz = f[a]['zPk'][...]
-            mass_bins = f[a]['mass_bins'][...]
-            mass_hist = f[a]['mass_hist'][...]
+    # extract diagnostics and plot them
+    for a in alist:
+        all_k = []
+        all_Pk = []
+        all_kz = []
+        all_Pkz = []
+        all_mass_bins = []
+        all_mass_hist = []
 
-            fig, axs = plt.subplots(1, 3)
-            axs[0].loglog(k, Pk)
-            axs[1].loglog(kz, Pkz)
+        fig, axs = plt.subplots(1, 3, figsize=(9, 3), layout="constrained")
+        cmap = mpl.colormaps['winter']
+
+        # Take colors at regular intervals spanning the colormap.
+        colors = cmap(np.linspace(0, 1, len(lhids)))
+        cmap = (mpl.colors.ListedColormap(colors))
+
+        for i, source_file in enumerate(source_files):
+            k, Pk, kz, Pkz, mass_bins, mass_hist = extract_halo_diagnostics(source_file, a)
+            all_k.append(k)
+            all_Pk.append(Pk)
+            all_kz.append(kz)
+            all_Pkz.append(Pkz)
+            all_mass_bins.append(mass_bins)
+            all_mass_hist.append(mass_hist)
+
+            axs[0].loglog(k, Pk[:, 0], color=colors[i], label=f'lhid = {lhids[i]}')
+            axs[1].loglog(kz, Pkz[:, 0], color=colors[i], label=f'lhid = {lhids[i]}')
             centered_bins = 0.5 * (mass_bins[:-1] + mass_bins[1:])
-            axs[2].loglog(centered_bins, mass_hist/L**3)
+            axs[2].loglog(10 ** centered_bins, mass_hist / L ** 3 / np.diff(mass_bins),
+                          color=colors[i], label=f'lhid = {lhids[i]}')
 
-            fig.savefig(out_file, format='svg')
+            # TOASK: do we want the mean behaviour as well?
+
+        out_file = join(outpath, f'halo_summ_group_{a}_lh_id_{lhids[0]}_to_{lhids[-1]}.svg')
+
+        k_nyquist = np.pi / (L / N)
+        axs[0].set_xlim(right=k_nyquist * 0.7)
+        axs[1].set_xlim(right=k_nyquist * 0.7)
+
+        bounds = (np.arange(len(lhids) + 1) - 0.5).tolist()
+        norm = mpl.colors.BoundaryNorm(bounds, cmap.N)
+        fig.colorbar(
+            mpl.cm.ScalarMappable(cmap=cmap, norm=norm),
+            ax=axs[:],
+            boundaries=bounds,
+            ticks=[lhids[0], lhids[-1]],
+            spacing='uniform',
+            orientation='vertical',
+            label='latin hypercube ids',
+            location='right'
+        )
+        fig.savefig(out_file, format='svg')
     return True
+
 
 @timing_decorator
 @hydra.main(version_base=None, config_path="../conf", config_name="config")
@@ -67,25 +128,44 @@ def main(cfg: DictConfig) -> None:
     logging.info('Running with config:\n' + OmegaConf.to_yaml(cfg))
 
     cfg = parse_nbody_config(cfg)
-    source_path = get_source_path(
-        cfg.meta.wdir, cfg.nbody.suite, cfg.sim,
-        cfg.nbody.L, cfg.nbody.N, cfg.nbody.lhid
-    )
 
-    out_dir = get_source_path(
-        cfg.meta.odir, cfg.nbody.suite, cfg.sim,
-        cfg.nbody.L, cfg.nbody.N, cfg.nbody.lhid,
-        mkdir=True
-    )
+    wdir = cfg.meta.wdir
+    odir = cfg.meta.odir
+    suite = cfg.nbody.suite
+    sim = cfg.sim
+    L = cfg.nbody.L
+    N = cfg.nbody.N
+    n_lhid_seeds = cfg.diag.n_seeds
 
-    from_scratch = cfg.diag.from_scratch
+    if n_lhid_seeds == 1:
+        lhids = cfg.nbody.lhid
+        source_path = get_source_path(
+            wdir, suite, sim,
+            L, N, lhids
+        )
+
+        out_dir = get_source_path(
+            odir, suite, sim,
+            L, N, lhids,
+            mkdir=True
+        )
+    else:
+        lhids = range(cfg.diag.lhid_start, n_lhid_seeds)
+        source_path = [get_source_path(
+            wdir, suite, sim,
+            L, N, lhid=lhid
+        ) for lhid in lhids]
+
+        out_dir = get_source_path(
+            odir, suite, sim,
+            L, N, lhid=0, get_cfg_dir=True
+        )
 
     all_done = True
 
     # measure halo diagnostics
     done = plot_halo_sum(
-        source_path, cfg.nbody.L, cfg.nbody.N, cfg.nbody.cosmo[2],
-        cfg.nbody.zf, from_scratch=from_scratch, out_dir=out_dir)
+        source_path, L, N, out_dir=out_dir, lhids=lhids)
     all_done &= done
 
     if all_done:

--- a/cmass/diagnostics/vis_summ.py
+++ b/cmass/diagnostics/vis_summ.py
@@ -253,8 +253,9 @@ def main(cfg: DictConfig) -> None:
         )
 
         compare_paths = [get_source_path(
-            wdir, 'quijote', 'nbody',
-            L, 128, lhid=lhids
+            # TODO: remove hard-coded comparison path
+            wdir, 'quijote', 'nbody_mvir',
+            L, N, lhid=lhids
         )]
 
         source_path = [source_path]
@@ -273,7 +274,8 @@ def main(cfg: DictConfig) -> None:
 
         # FIXME: integrate this into the hydra configuration
         compare_paths = [get_source_path(
-            wdir, 'quijote', 'nbody',
+            # TODO: remove hard-coded comparison path
+            wdir, 'quijote', 'nbody_mvir',
             L, N, lhid=lhid
         ) for lhid in lhids]
 

--- a/cmass/diagnostics/vis_summ.py
+++ b/cmass/diagnostics/vis_summ.py
@@ -193,12 +193,12 @@ def plot_halo_sum(source_path, L, N, out_dir, lhids, compare_paths):
             axs_comp_ensemble[1].set_xlabel(r"$k$ [$h\,\mathrm{Mpc}^{-1}$]")
 
             finalise_halo_summ_fig(L, N, a, axs_comp_ensemble, cmap, fig_comp_ensemble, lhids, outpath,
-                                   prefix='halo_summ_comparison_ensemble', no_cmap=True)
+                                   prefix='halo_summ_comparison_ensemble', include_cmap=False)
 
     return True
 
 
-def finalise_halo_summ_fig(L, N, a, axs, cmap, fig, lhids, outpath, prefix, no_cmap=False):
+def finalise_halo_summ_fig(L, N, a, axs, cmap, fig, lhids, outpath, prefix, include_cmap=True):
     if len(lhids) == 1:
         file_name = f'{prefix}_group_{a}_lhid_{lhids[0]}.png'
     else:
@@ -209,7 +209,7 @@ def finalise_halo_summ_fig(L, N, a, axs, cmap, fig, lhids, outpath, prefix, no_c
     axs[0].set_xlim(right=k_nyquist * 0.7)
     axs[1].set_xlim(right=k_nyquist * 0.7)
 
-    if len(lhids) > 1 or no_cmap:
+    if len(lhids) > 1 and include_cmap:
         bounds = (np.arange(len(lhids) + 1) - 0.5).tolist()
         norm = mpl.colors.BoundaryNorm(bounds, cmap.N)
         fig.colorbar(

--- a/cmass/diagnostics/vis_summ.py
+++ b/cmass/diagnostics/vis_summ.py
@@ -20,7 +20,7 @@ from ..nbody.tools import parse_nbody_config
 
 
 def check_diagnostics_exist(path, diag_dir, diag_file):
-    source_file = join(path, 'diag', 'halos.h5')
+    source_file = join(path, diag_dir, diag_file)
     if os.path.isfile(source_file):
         logging.info('Halo diagnostics already computed. Proceeding with visualisation.')
         return True
@@ -45,10 +45,6 @@ def extract_halo_diagnostics(file_path, group):
 def plot_halo_sum(source_path, L, N, out_dir, lhids):
     # TODO: Implement use of mpl style files
     # plt.style.use('/home/sding/PhD/codes/ltu-cmass/cmass/conf/diag/aa_one_column.mplstyle')
-
-    if len(source_path) == 1:
-        source_path = [source_path]
-        lhids = [lhids]
 
     # check if diagnostics is computed
     all_diagnostics_exist = np.all([check_diagnostics_exist(path, 'diag', 'halos.h5')
@@ -149,6 +145,8 @@ def main(cfg: DictConfig) -> None:
             L, N, lhids,
             mkdir=True
         )
+        source_path = [source_path]
+        lhids = [lhids]
     else:
         lhids = range(cfg.diag.lhid_start, n_lhid_seeds)
         source_path = [get_source_path(

--- a/cmass/diagnostics/vis_summ.py
+++ b/cmass/diagnostics/vis_summ.py
@@ -1,0 +1,97 @@
+"""
+A script to visualise basic summary statistics for all fields generated during
+the simulation.
+Can be also used to compare between different runs.
+"""
+
+import os
+
+import matplotlib.pyplot as plt
+import numpy as np
+import logging
+from os.path import join
+import hydra
+from omegaconf import DictConfig, OmegaConf
+import h5py
+
+from ..utils import get_source_path, timing_decorator
+from ..nbody.tools import parse_nbody_config
+
+
+def plot_halo_sum(source_path, L, N, h, z, from_scratch=True, out_dir=None):
+    if out_dir is None:
+        out_dir = source_path
+
+    # check if diagnostics is computed
+    source_file = join(source_path, 'diag', 'halos.h5')
+    if os.path.isfile(source_path):
+        logging.info('Halo diagnostics already computed. Proceeding with visualisation.')
+    else:
+        logging.error(f'{source_file} with halo diagnostics not found.')
+        return False
+
+    # check for file keys
+    with h5py.File(source_file, 'r') as f:
+        alist = list(f.keys())
+
+    outpath = join(out_dir, 'diag')
+    os.makedirs(outpath, exist_ok=True)
+    logging.info(f'Saving halo diagnostics to {outpath}')
+
+    # compute diagnostics and save
+    with h5py.File(source_file, 'r') as f:
+        for a in alist:
+            out_file = join(outpath, f'halo_summ_group{a}')
+            # Load
+            k = f[a]['Pk_k'][...]
+            Pk = f[a]['Pk'][...]
+            kz = f[a]['zPk_k'][...]
+            Pkz = f[a]['zPk'][...]
+            mass_bins = f[a]['mass_bins'][...]
+            mass_hist = f[a]['mass_hist'][...]
+
+            fig, axs = plt.subplots(1, 3)
+            axs[0].loglog(k, Pk)
+            axs[1].loglog(kz, Pkz)
+            axs[2].loglog(mass_bins, mass_hist/L**3)
+
+            fig.savefig(out_file)
+    return True
+
+@timing_decorator
+@hydra.main(version_base=None, config_path="../conf", config_name="config")
+def main(cfg: DictConfig) -> None:
+    # Filtering for necessary configs
+    cfg = OmegaConf.masked_copy(cfg, ['meta', 'sim', 'nbody', 'bias', 'diag'])
+    logging.info('Running with config:\n' + OmegaConf.to_yaml(cfg))
+
+    cfg = parse_nbody_config(cfg)
+    source_path = get_source_path(
+        cfg.meta.wdir, cfg.nbody.suite, cfg.sim,
+        cfg.nbody.L, cfg.nbody.N, cfg.nbody.lhid
+    )
+
+    out_dir = get_source_path(
+        cfg.meta.odir, cfg.nbody.suite, cfg.sim,
+        cfg.nbody.L, cfg.nbody.N, cfg.nbody.lhid,
+        mkdir=True
+    )
+
+    from_scratch = cfg.diag.from_scratch
+
+    all_done = True
+
+    # measure halo diagnostics
+    done = plot_halo_sum(
+        source_path, cfg.nbody.L, cfg.nbody.N, cfg.nbody.cosmo[2],
+        cfg.nbody.zf, from_scratch=from_scratch, out_dir=out_dir)
+    all_done &= done
+
+    if all_done:
+        logging.info('All diagnostics computed successfully')
+    else:
+        logging.error('Some diagnostics failed to compute')
+
+
+if __name__ == "__main__":
+    main()

--- a/cmass/diagnostics/vis_summ.py
+++ b/cmass/diagnostics/vis_summ.py
@@ -42,7 +42,14 @@ def extract_halo_diagnostics(file_path, group):
         return k, Pk, kz, Pkz, mass_bins, mass_hist
 
 
-def plot_halo_sum(source_path, L, N, out_dir, lhids):
+def check_gen_comparison(config):
+    same_wdir = config.meta.wdir == config.diag.compare.wdir
+    same_nbody = config.nbody == config.diag.compare.nbody
+    same_sim = config.sim == config.diag.compare.sim
+    return same_wdir and same_nbody and same_sim
+
+
+def plot_halo_sum(source_path, L, N, out_dir, lhids, compare_paths):
     # TODO: Implement use of mpl style files
     # plt.style.use('/home/sding/PhD/codes/ltu-cmass/cmass/conf/diag/aa_one_column.mplstyle')
 
@@ -53,6 +60,7 @@ def plot_halo_sum(source_path, L, N, out_dir, lhids):
         return False
 
     source_files = [join(path, 'diag', 'halos.h5') for path in source_path]
+    compare_files = [join(path, 'diag', 'halos.h5') for path in compare_paths]
     # check for file keys
     with h5py.File(source_files[0], 'r') as f:
         alist = list(f.keys())
@@ -70,6 +78,13 @@ def plot_halo_sum(source_path, L, N, out_dir, lhids):
         all_mass_bins = []
         all_mass_hist = []
 
+        all_k_comp = []
+        all_Pk_comp = []
+        all_kz_comp = []
+        all_Pkz_comp = []
+        all_mass_bins_comp = []
+        all_mass_hist_comp = []
+
         fig, axs = plt.subplots(1, 3, figsize=(9, 3), layout="constrained")
         cmap = mpl.colormaps['winter']
 
@@ -78,13 +93,12 @@ def plot_halo_sum(source_path, L, N, out_dir, lhids):
         cmap = (mpl.colors.ListedColormap(colors))
 
         for i, source_file in enumerate(source_files):
-            k, Pk, kz, Pkz, mass_bins, mass_hist = extract_halo_diagnostics(source_file, a)
-            all_k.append(k)
-            all_Pk.append(Pk)
-            all_kz.append(kz)
-            all_Pkz.append(Pkz)
-            all_mass_bins.append(mass_bins)
-            all_mass_hist.append(mass_hist)
+            Pk, Pkz, k, kz, mass_bins, mass_hist = append_halo_summs(a, all_Pk, all_Pkz, all_k, all_kz, all_mass_bins,
+                                                                     all_mass_hist, source_file)
+
+            append_halo_summs(a, all_Pk_comp, all_Pkz_comp, all_k_comp,
+                              all_kz_comp, all_mass_bins_comp,
+                              all_mass_hist_comp, compare_files[i])
 
             axs[0].loglog(k, Pk[:, 0], color=colors[i], label=f'lhid = {lhids[i]}')
             axs[1].loglog(kz, Pkz[:, 0], color=colors[i], label=f'lhid = {lhids[i]}')
@@ -113,7 +127,97 @@ def plot_halo_sum(source_path, L, N, out_dir, lhids):
             location='right'
         )
         fig.savefig(out_file, format='svg')
+
+        fig_comp, axs_comp = plt.subplots(1, 3, figsize=(9, 3), layout="constrained")
+        fig_comp_ensemble, axs_comp_ensemble = plt.subplots(1, 3, figsize=(9, 3), layout="constrained")
+        Pk_ratios = []
+        Pkz_ratios = []
+        hmf_ratios = []
+
+        for i, source_file in enumerate(source_files):
+            ratio_Pk_i = all_Pk[i][:, 0] / all_Pk_comp[i][:, 0]
+            axs_comp[0].semilogx(all_k[i], ratio_Pk_i, color=colors[i])
+            ratio_Pkz_i = all_Pkz[i][:, 0] / all_Pk_comp[i][:, 0]
+            axs_comp[1].semilogx(all_kz[i], ratio_Pkz_i, color=colors[i])
+            centered_bins = 0.5 * (all_mass_bins[i][:-1] + all_mass_bins[i][1:])
+
+            hmf = all_mass_hist[i] / L ** 3 / np.diff(all_mass_bins[i])
+            hmf_comp = all_mass_hist_comp[i] / L ** 3 / np.diff(all_mass_bins[i])
+            ratio_hmf_i = hmf / hmf_comp
+            axs_comp[2].semilogx(10 ** centered_bins, ratio_hmf_i,
+                                 color=colors[i])
+            Pk_ratios.append(ratio_Pk_i)
+            Pkz_ratios.append(ratio_Pkz_i)
+            hmf_ratios.append(ratio_hmf_i)
+
+        out_file = join(outpath, f'halo_comp_group_{a}_lh_id_{lhids[0]}_to_{lhids[-1]}.svg')
+
+        k_nyquist = np.pi / (L / N)
+        axs_comp[0].set_xlim(right=k_nyquist * 0.7)
+        axs_comp[1].set_xlim(right=k_nyquist * 0.7)
+
+        bounds = (np.arange(len(lhids) + 1) - 0.5).tolist()
+        norm = mpl.colors.BoundaryNorm(bounds, cmap.N)
+        fig_comp.colorbar(
+            mpl.cm.ScalarMappable(cmap=cmap, norm=norm),
+            ax=axs_comp[:],
+            boundaries=bounds,
+            ticks=[lhids[0], lhids[-1]],
+            spacing='uniform',
+            orientation='vertical',
+            label='latin hypercube ids',
+            location='right'
+        )
+        fig_comp.savefig(out_file, format='svg')
+
+        ## Ensemble plot
+        mean_pk = np.mean(Pk_ratios, axis=0)
+        std_pk = np.std(Pk_ratios, axis=0)
+        axs_comp_ensemble[0].semilogx(all_k[0], mean_pk, color='k')
+        axs_comp_ensemble[0].fill_between(all_k[0], mean_pk - std_pk, mean_pk + std_pk, color='k', alpha=0.2)
+
+        mean_pk_z = np.mean(Pkz_ratios, axis=0)
+        std_pk_z = np.std(Pkz_ratios, axis=0)
+        axs_comp_ensemble[1].semilogx(all_kz[0], mean_pk_z, color='k')
+        axs_comp_ensemble[1].fill_between(all_kz[0], mean_pk_z - std_pk_z, mean_pk_z + std_pk_z, color='k', alpha=0.2)
+        mean_hmf = np.mean(hmf_ratios, axis=0)
+        std_hmf = np.std(hmf_ratios, axis=0)
+        axs_comp_ensemble[2].semilogx(10 ** centered_bins, mean_hmf, color='k')
+        axs_comp_ensemble[2].fill_between(10 ** centered_bins, mean_hmf - std_hmf, mean_hmf + std_hmf, color='k',
+                                          alpha=0.2)
+
+        out_file = join(outpath, f'halo_comp_ensemble_group_{a}_lh_id_{lhids[0]}_to_{lhids[-1]}.svg')
+
+        k_nyquist = np.pi / (L / N)
+        axs_comp_ensemble[0].set_xlim(right=k_nyquist * 0.7)
+        axs_comp_ensemble[1].set_xlim(right=k_nyquist * 0.7)
+
+        bounds = (np.arange(len(lhids) + 1) - 0.5).tolist()
+        norm = mpl.colors.BoundaryNorm(bounds, cmap.N)
+        fig_comp_ensemble.colorbar(
+            mpl.cm.ScalarMappable(cmap=cmap, norm=norm),
+            ax=axs_comp[:],
+            boundaries=bounds,
+            ticks=[lhids[0], lhids[-1]],
+            spacing='uniform',
+            orientation='vertical',
+            label='latin hypercube ids',
+            location='right'
+        )
+        fig_comp_ensemble.savefig(out_file, format='svg')
+
     return True
+
+
+def append_halo_summs(a, all_Pk, all_Pkz, all_k, all_kz, all_mass_bins, all_mass_hist, source_file):
+    k, Pk, kz, Pkz, mass_bins, mass_hist = extract_halo_diagnostics(source_file, a)
+    all_k.append(k)
+    all_Pk.append(Pk)
+    all_kz.append(kz)
+    all_Pkz.append(Pkz)
+    all_mass_bins.append(mass_bins)
+    all_mass_hist.append(mass_hist)
+    return Pk, Pkz, k, kz, mass_bins, mass_hist
 
 
 @timing_decorator
@@ -133,6 +237,8 @@ def main(cfg: DictConfig) -> None:
     N = cfg.nbody.N
     n_lhid_seeds = cfg.diag.n_seeds
 
+    # generate_comparison = check_gen_comparison(cfg)
+
     if n_lhid_seeds == 1:
         lhids = cfg.nbody.lhid
         source_path = get_source_path(
@@ -145,10 +251,16 @@ def main(cfg: DictConfig) -> None:
             L, N, lhids,
             mkdir=True
         )
+
+        compare_paths = [get_source_path(
+            wdir, 'quijotelike', 'fastpm',
+            L, N, lhid=lhids
+        )]
+
         source_path = [source_path]
         lhids = [lhids]
     else:
-        lhids = range(cfg.diag.lhid_start, n_lhid_seeds)
+        lhids = range(cfg.diag.lhid_start, cfg.diag.lhid_start + n_lhid_seeds)
         source_path = [get_source_path(
             wdir, suite, sim,
             L, N, lhid=lhid
@@ -159,11 +271,17 @@ def main(cfg: DictConfig) -> None:
             L, N, lhid=0, get_cfg_dir=True
         )
 
+        # FIXME: integrate this into the hydra configuration
+        compare_paths = [get_source_path(
+            wdir, 'quijotelike', 'fastpm',
+            L, N, lhid=lhid
+        ) for lhid in lhids]
+
     all_done = True
 
     # measure halo diagnostics
     done = plot_halo_sum(
-        source_path, L, N, out_dir=out_dir, lhids=lhids)
+        source_path, L, N, out_dir=out_dir, lhids=lhids, compare_paths=compare_paths)
     all_done &= done
 
     if all_done:

--- a/cmass/diagnostics/vis_summ.py
+++ b/cmass/diagnostics/vis_summ.py
@@ -159,12 +159,12 @@ def plot_halo_sum(source_path, L, N, out_dir, lhids, compare_paths):
                                               alpha=0.2)
 
             finalise_halo_summ_fig(L, N, a, axs_comp_ensemble, cmap, fig_comp_ensemble, lhids, outpath,
-                                   prefix='halo_summ_comparison_ensemble')
+                                   prefix='halo_summ_comparison_ensemble', no_cmap=True)
 
     return True
 
 
-def finalise_halo_summ_fig(L, N, a, axs, cmap, fig, lhids, outpath, prefix):
+def finalise_halo_summ_fig(L, N, a, axs, cmap, fig, lhids, outpath, prefix, no_cmap=False):
     if len(lhids) == 1:
         file_name = f'{prefix}_group_{a}_lhid_{lhids[0]}.png'
     else:
@@ -175,7 +175,7 @@ def finalise_halo_summ_fig(L, N, a, axs, cmap, fig, lhids, outpath, prefix):
     axs[0].set_xlim(right=k_nyquist * 0.7)
     axs[1].set_xlim(right=k_nyquist * 0.7)
 
-    if len(lhids) > 1:
+    if len(lhids) > 1 or no_cmap:
         bounds = (np.arange(len(lhids) + 1) - 0.5).tolist()
         norm = mpl.colors.BoundaryNorm(bounds, cmap.N)
         fig.colorbar(
@@ -192,18 +192,6 @@ def finalise_halo_summ_fig(L, N, a, axs, cmap, fig, lhids, outpath, prefix):
         fig.suptitle(f'Latin-hypercube id: {lhids[0]}')
     logging.info(f'Saving figure as {out_file}')
     fig.savefig(out_file, format='png', dpi=300)
-
-
-def append_halo_summs(a, all_Pk, all_Pkz, all_k, all_kz, all_mass_bins, all_mass_hist, source_file):
-    k, Pk, kz, Pkz, mass_bins, mass_hist = extract_halo_diagnostics(source_file, a)
-    # halo_summ = extract_halo_diagnostics(source_file, a)
-    all_k.append(k)
-    all_Pk.append(Pk)
-    all_kz.append(kz)
-    all_Pkz.append(Pkz)
-    all_mass_bins.append(mass_bins)
-    all_mass_hist.append(mass_hist)
-    return Pk, Pkz, k, kz, mass_bins, mass_hist
 
 
 @timing_decorator

--- a/cmass/diagnostics/vis_summ.py
+++ b/cmass/diagnostics/vis_summ.py
@@ -59,12 +59,23 @@ def check_gen_comparison(config):
 def plot_std_halo_summ(axs, halo_summ: HalosStdSummary, L, lhid, color):
     k, Pk = halo_summ['Pk_k'], halo_summ['Pk']
     axs[0].loglog(k, Pk[:, 0], color=color, label=f'lhid = {lhid}')
+    axs[0].set_title(r'Comoving $P(k)$')
+    axs[0].set_ylabel(r"$P(k)$ [$h^{-3}\,\mathrm{Mpc}^3$]")
+    axs[0].set_xlabel(r"$k$ [$h\,\mathrm{Mpc}^{-1}$]")
+
     kz, Pkz = halo_summ['zPk_k'], halo_summ['zPk']
     axs[1].loglog(kz, Pkz[:, 0], color=color, label=f'lhid = {lhid}')
+    axs[1].set_title(r'Redshift space $P(k)$')
+    axs[1].set_ylabel(r"$P(k)$ [$h^{-3}\,\mathrm{Mpc}^3$]")
+    axs[1].set_xlabel(r"$k$ [$h\,\mathrm{Mpc}^{-1}$]")
+
     mass_bins, mass_hist = halo_summ['mass_bins'], halo_summ['mass_hist']
     centered_bins = 0.5 * (mass_bins[:-1] + mass_bins[1:])
     axs[2].loglog(10 ** centered_bins, mass_hist / L ** 3 / np.diff(mass_bins),
                   color=color, label=f'lhid = {lhid}')
+    axs[2].set_title(r'Halo mass function')
+    axs[2].set_ylabel("$n(M)\ [h^{3}\\mathrm{Mpc}^{-3}]$")
+    axs[2].set_xlabel(r"$M [M_\odot]$")
 
 
 def plot_halo_sum(source_path, L, N, out_dir, lhids, compare_paths):
@@ -135,6 +146,16 @@ def plot_halo_sum(source_path, L, N, out_dir, lhids, compare_paths):
                 Pkz_ratios.append(ratio_Pkz_i)
                 hmf_ratios.append(ratio_hmf_i)
 
+            axs_comp[0].hlines(1, 0, 2, colors='k', lw=0.4)
+            axs_comp[0].set_title(r'Comoving $P(k)$')
+            axs_comp[0].set_ylabel(r"$P(k) / P_{\mathrm{ref}}(k)$")
+            axs_comp[0].set_xlabel(r"$k$ [$h\,\mathrm{Mpc}^{-1}$]")
+            axs_comp[1].hlines(1, 0, 2, colors='k', lw=0.4)
+            axs_comp[1].set_title(r'Redshift space $P(k)$')
+            axs_comp[1].set_ylabel(r"$P(k) / P_{\mathrm{ref}}(k)$")
+            axs_comp[1].set_xlabel(r"$k$ [$h\,\mathrm{Mpc}^{-1}$]")
+            # axs_comp[2].hlines(1, 10**13, 10**16, colors='k', lw=0.4)
+
             finalise_halo_summ_fig(L, N, a, axs_comp, cmap, fig_comp, lhids, outpath, prefix='halo_summ_comparison')
 
             # Ensemble ratio plot
@@ -157,6 +178,15 @@ def plot_halo_sum(source_path, L, N, out_dir, lhids, compare_paths):
             axs_comp_ensemble[2].semilogx(10 ** centered_bins, mean_hmf, color='k')
             axs_comp_ensemble[2].fill_between(10 ** centered_bins, mean_hmf - std_hmf, mean_hmf + std_hmf, color='k',
                                               alpha=0.2)
+
+            axs_comp_ensemble[0].hlines(1, 0, 2, colors='k', lw=0.4)
+            axs_comp_ensemble[0].set_title(r'Comoving $P(k)$')
+            axs_comp_ensemble[0].set_ylabel(r"$P(k) / P_{\mathrm{ref}}(k)$")
+            axs_comp_ensemble[0].set_xlabel(r"$k$ [$h\,\mathrm{Mpc}^{-1}$]")
+            axs_comp_ensemble[1].hlines(1, 0, 2, colors='k', lw=0.4)
+            axs_comp_ensemble[1].set_title(r'Redshift space $P(k)$')
+            axs_comp_ensemble[1].set_ylabel(r"$P(k) / P_{\mathrm{ref}}(k)$")
+            axs_comp_ensemble[1].set_xlabel(r"$k$ [$h\,\mathrm{Mpc}^{-1}$]")
 
             finalise_halo_summ_fig(L, N, a, axs_comp_ensemble, cmap, fig_comp_ensemble, lhids, outpath,
                                    prefix='halo_summ_comparison_ensemble', no_cmap=True)

--- a/cmass/diagnostics/vis_summ.py
+++ b/cmass/diagnostics/vis_summ.py
@@ -53,7 +53,8 @@ def plot_halo_sum(source_path, L, N, h, z, from_scratch=True, out_dir=None):
             fig, axs = plt.subplots(1, 3)
             axs[0].loglog(k, Pk)
             axs[1].loglog(kz, Pkz)
-            axs[2].loglog(mass_bins, mass_hist/L**3)
+            centered_bins = 0.5 * (mass_bins[:-1] + mass_bins[1:])
+            axs[2].loglog(centered_bins, mass_hist/L**3)
 
             fig.savefig(out_file)
     return True

--- a/cmass/diagnostics/vis_summ.py
+++ b/cmass/diagnostics/vis_summ.py
@@ -41,7 +41,7 @@ def plot_halo_sum(source_path, L, N, h, z, from_scratch=True, out_dir=None):
     # compute diagnostics and save
     with h5py.File(source_file, 'r') as f:
         for a in alist:
-            out_file = join(outpath, f'halo_summ_group{a}')
+            out_file = join(outpath, f'halo_summ_group{a}.svg')
             # Load
             k = f[a]['Pk_k'][...]
             Pk = f[a]['Pk'][...]
@@ -56,7 +56,7 @@ def plot_halo_sum(source_path, L, N, h, z, from_scratch=True, out_dir=None):
             centered_bins = 0.5 * (mass_bins[:-1] + mass_bins[1:])
             axs[2].loglog(centered_bins, mass_hist/L**3)
 
-            fig.savefig(out_file)
+            fig.savefig(out_file, format='svg')
     return True
 
 @timing_decorator

--- a/cmass/diagnostics/vis_summ.py
+++ b/cmass/diagnostics/vis_summ.py
@@ -260,7 +260,7 @@ def main(cfg: DictConfig) -> None:
         source_path = [source_path]
         lhids = [lhids]
     else:
-        lhids = range(cfg.diag.lhid_start, cfg.diag.lhid_start + n_lhid_seeds)
+        lhids = range(cfg.nbody.lhid, cfg.nbody.lhid + n_lhid_seeds)
         source_path = [get_source_path(
             wdir, suite, sim,
             L, N, lhid=lhid

--- a/cmass/diagnostics/vis_summ.py
+++ b/cmass/diagnostics/vis_summ.py
@@ -149,10 +149,12 @@ def plot_halo_sum(source_path, L, N, out_dir, lhids, compare_paths):
             axs_comp[0].hlines(1, 0, 2, colors='k', lw=0.4)
             axs_comp[0].set_title(r'Comoving $P(k)$')
             axs_comp[0].set_ylabel(r"$P(k) / P_{\mathrm{ref}}(k)$")
+            axs_comp[0].set_ylim(0, 2)
             axs_comp[0].set_xlabel(r"$k$ [$h\,\mathrm{Mpc}^{-1}$]")
             axs_comp[1].hlines(1, 0, 2, colors='k', lw=0.4)
             axs_comp[1].set_title(r'Redshift space $P(k)$')
             axs_comp[1].set_ylabel(r"$P(k) / P_{\mathrm{ref}}(k)$")
+            axs_comp[1].set_ylim(0, 2)
             axs_comp[1].set_xlabel(r"$k$ [$h\,\mathrm{Mpc}^{-1}$]")
             # axs_comp[2].hlines(1, 10**13, 10**16, colors='k', lw=0.4)
 
@@ -182,10 +184,12 @@ def plot_halo_sum(source_path, L, N, out_dir, lhids, compare_paths):
             axs_comp_ensemble[0].hlines(1, 0, 2, colors='k', lw=0.4)
             axs_comp_ensemble[0].set_title(r'Comoving $P(k)$')
             axs_comp_ensemble[0].set_ylabel(r"$P(k) / P_{\mathrm{ref}}(k)$")
+            axs_comp_ensemble[0].set_ylim(0, 2)
             axs_comp_ensemble[0].set_xlabel(r"$k$ [$h\,\mathrm{Mpc}^{-1}$]")
             axs_comp_ensemble[1].hlines(1, 0, 2, colors='k', lw=0.4)
             axs_comp_ensemble[1].set_title(r'Redshift space $P(k)$')
             axs_comp_ensemble[1].set_ylabel(r"$P(k) / P_{\mathrm{ref}}(k)$")
+            axs_comp_ensemble[1].set_ylim(0, 2)
             axs_comp_ensemble[1].set_xlabel(r"$k$ [$h\,\mathrm{Mpc}^{-1}$]")
 
             finalise_halo_summ_fig(L, N, a, axs_comp_ensemble, cmap, fig_comp_ensemble, lhids, outpath,

--- a/cmass/diagnostics/vis_summ.py
+++ b/cmass/diagnostics/vis_summ.py
@@ -60,7 +60,9 @@ def plot_halo_sum(source_path, L, N, out_dir, lhids, compare_paths):
         return False
 
     source_files = [join(path, 'diag', 'halos.h5') for path in source_path]
+    logging.info(f'Loaded diagnostics from {source_path}')
     compare_files = [join(path, 'diag', 'halos.h5') for path in compare_paths]
+    logging.info(f'Loaded diagnostics from {compare_paths}')
     # check for file keys
     with h5py.File(source_files[0], 'r') as f:
         alist = list(f.keys())

--- a/cmass/diagnostics/vis_summ.py
+++ b/cmass/diagnostics/vis_summ.py
@@ -273,7 +273,7 @@ def main(cfg: DictConfig) -> None:
 
         # FIXME: integrate this into the hydra configuration
         compare_paths = [get_source_path(
-            wdir, 'quijotelike', 'fastpm',
+            wdir, 'quijote', 'nbody',
             L, N, lhid=lhid
         ) for lhid in lhids]
 

--- a/cmass/utils/utils.py
+++ b/cmass/utils/utils.py
@@ -8,7 +8,7 @@ from colossus.cosmology import cosmology as csm
 from omegaconf import OmegaConf
 
 
-def get_source_path(wdir, suite, sim, L, N, lhid, check=True, mkdir=False):
+def get_source_path(wdir, suite, sim, L, N, lhid, check=True, mkdir=False, get_cfg_dir=False):
     # get the path to the source directory, and check at each level
     sim_dir = join(wdir, suite, sim)
     cfg_dir = join(sim_dir, f'L{L}-N{N}')
@@ -17,6 +17,9 @@ def get_source_path(wdir, suite, sim, L, N, lhid, check=True, mkdir=False):
     if mkdir:
         os.makedirs(sim_dir, exist_ok=True)
         os.makedirs(cfg_dir, exist_ok=True)
+        if get_cfg_dir:
+            return cfg_dir
+
         os.makedirs(lh_dir, exist_ok=True)
         return lh_dir
 
@@ -27,9 +30,13 @@ def get_source_path(wdir, suite, sim, L, N, lhid, check=True, mkdir=False):
         if not os.path.isdir(cfg_dir):
             raise ValueError(
                 f"Configuration directory {cfg_dir} does not exist.")
-        if not os.path.isdir(lh_dir):
-            raise ValueError(
-                f"Latin hypercube directory {lh_dir} does not exist.")
+        if not get_cfg_dir:
+            if not os.path.isdir(lh_dir):
+                raise ValueError(
+                    f"Latin hypercube directory {lh_dir} does not exist.")
+
+    if get_cfg_dir:
+        return cfg_dir
 
     return lh_dir
 

--- a/cmass/utils/utils.py
+++ b/cmass/utils/utils.py
@@ -8,11 +8,17 @@ from colossus.cosmology import cosmology as csm
 from omegaconf import OmegaConf
 
 
-def get_source_path(wdir, suite, sim, L, N, lhid, check=True):
+def get_source_path(wdir, suite, sim, L, N, lhid, check=True, mkdir=False):
     # get the path to the source directory, and check at each level
     sim_dir = join(wdir, suite, sim)
     cfg_dir = join(sim_dir, f'L{L}-N{N}')
     lh_dir = join(cfg_dir, str(lhid))
+
+    if mkdir:
+        os.makedirs(sim_dir, exist_ok=True)
+        os.makedirs(cfg_dir, exist_ok=True)
+        os.makedirs(lh_dir, exist_ok=True)
+        return lh_dir
 
     if check:
         if not os.path.isdir(sim_dir):
@@ -24,6 +30,7 @@ def get_source_path(wdir, suite, sim, L, N, lhid, check=True):
         if not os.path.isdir(lh_dir):
             raise ValueError(
                 f"Latin hypercube directory {lh_dir} does not exist.")
+
     return lh_dir
 
 


### PR DESCRIPTION
- Added module `cmass.diagnostics.vis_summ` to visualise the power spectrum and halo mass function for a given halo catalogue
- Added option to save diagnostics to another folder through `meta.odir`
- Added option to compare the different diagnostics with another suite of simulations through `diag.make_comparison=bool`, `diag.compare_sim`, and `diag.compare_suite`
- The new module outputs the halo diagnostics for the individual latin hypercube seeds, the individual ratios and the mean and standard deviation over an ensemble of ratios

An example of plotting the individual halo diagnostics for the first 100 latin hypercube seeds, generated via
`python -m cmass.diagnostics.vis_summ meta.wdir=/data80/sding/ltu-cmass nbody=quijotelike sim=pinocchio diag.n_seeds=100 nbody.lhid=0`
![halo_summ_group_0 666667_lhid_0_to_99](https://github.com/user-attachments/assets/28a6f189-2a92-4339-8c75-23412f3b1266)

An example for the comparison plots against Quijote halos, generated by adding `diag.make_comparison=true diag.compare_suite=quijote diag.compare_sim=nbody_mvir` to the previous command

![halo_summ_comparison_ensemble_group_0 666667_lhid_0_to_99](https://github.com/user-attachments/assets/f02d86ef-b794-442c-8f30-a4012c6d66a6)
![halo_summ_comparison_group_0 666667_lhid_0_to_99](https://github.com/user-attachments/assets/89bfefc0-1d71-48e1-a0f1-69e4ac6c813c)

Running the visualization module presumes that the diagnostics have already been computed. To compute the diagnostics with a different output directory one can run for instance
`python -m cmass.diagnostics.summ meta.wdir=$SOMEDATADIR/ili/cmass meta.odir=$OUTPUTDIR/ltu-cmass nbody=quijotelike sim=pinocchio nbody.lhid=$i`