### PR TITLE
New HOD models

### DIFF
--- a/cmass/bias/apply_hod.py
+++ b/cmass/bias/apply_hod.py
@@ -1,5 +1,6 @@
 """
-Sample an HOD realization from the halo catalog using the Zheng+(2007) model.
+Sample an HOD realization from the halo catalog.
+HOD model and parameters defined in the bias configuration file.
 
 Input:
     - halos.h5
@@ -46,17 +47,8 @@ def populate_hod(
         mdef=mdef
     )
 
-    # hod_params = cfg.bias.hod.theta
-
-    hod = build_HOD_model(
-        # cosmo, cfg.nbody.zf, hod_model='zheng07', mdef=mdef,
-        # cosmo, cfg.nbody.zf, mdef=mdef,
-        cosmo, cfg, mdef=mdef,
-        # **hod_params
-    )
-
+    hod = build_HOD_model(cosmo, cfg, mdef=mdef)
     hod.populate_mock(catalog, seed=seed)
-
     galcat = hod.mock.galaxy_table.as_array()
 
     return galcat

--- a/cmass/bias/apply_hod.py
+++ b/cmass/bias/apply_hod.py
@@ -53,6 +53,7 @@ def populate_hod(
         cosmo,
         model=model,
         theta=theta,
+        zf=zf,
         mdef=mdef
     )
     hod.populate_mock(catalog, seed=seed)

--- a/cmass/bias/apply_hod.py
+++ b/cmass/bias/apply_hod.py
@@ -16,7 +16,6 @@ Output:
         - hostid: host halo ID
 
 NOTE:
-    - TODO: Implement Zheng+ex 10-parameter model
     - TODO: Allow cosmology-dependent HOD priors
 """
 

--- a/cmass/bias/apply_hod.py
+++ b/cmass/bias/apply_hod.py
@@ -37,17 +37,24 @@ from ..nbody.tools import parse_nbody_config
 @ timing_decorator
 def populate_hod(
     hpos, hvel, hmass,
-    cosmo, cfg, seed=0, mdef='vir'
+    cosmo, L, zf,
+    model, theta, 
+    seed=0, mdef='vir'
 ):
     cosmo = cosmo_to_astropy(cosmo)
 
-    BoxSize = cfg.nbody.L*np.ones(3)
+    BoxSize = L*np.ones(3)
     catalog = build_halo_catalog(
-        hpos, hvel, 10**hmass, cfg.nbody.zf, BoxSize, cosmo,
+        hpos, hvel, 10**hmass, zf, BoxSize, cosmo,
         mdef=mdef
     )
 
-    hod = build_HOD_model(cosmo, cfg, mdef=mdef)
+    hod = build_HOD_model(
+        cosmo,
+        model=model,
+        theta=theta,
+        mdef=mdef
+    )
     hod.populate_mock(catalog, seed=seed)
     galcat = hod.mock.galaxy_table.as_array()
 
@@ -59,7 +66,8 @@ def run_snapshot(pos, vel, mass, cfg):
     logging.info('Populating HOD...')
     hod = populate_hod(
         pos, vel, mass,
-        cfg.nbody.cosmo, cfg,
+        cfg.nbody.cosmo, cfg.nbody.L, cfg.nbody.zf,
+        cfg.bias.hod.model, cfg.bias.hod.theta,
         seed=cfg.bias.hod.seed
     )
 

--- a/cmass/bias/tools/hod.py
+++ b/cmass/bias/tools/hod.py
@@ -64,7 +64,7 @@ def parse_hod(cfg):
             param = float(getattr(cfg.bias.hod, key))
             model.set_parameter(key, param)
 
-        # Chek if 'seed' set
+        # Check if 'seed' set
         if hasattr(cfg.bias.hod, 'seed'):
             if cfg.bias.hod.seed is not None:
                 # If -1, set to some random value

--- a/cmass/bias/tools/hod.py
+++ b/cmass/bias/tools/hod.py
@@ -54,15 +54,10 @@ def parse_hod(cfg):
             raise NotImplementedError
 
         # Then check if we're using default parameters
-        if hasattr(cfg.bias.hod, 'param_defaults'):
-            if cfg.bias.hod.param_defaults is not None:
+        if hasattr(cfg.bias.hod, 'default_params'):
+            if cfg.bias.hod.default_params is not None:
                 # Assign parameters given this default
-                getattr(model, cfg.bias.hod.param_defaults)()
-
-        # Update any additionally defined parameters
-        for key in model.parameters:
-            param = float(getattr(cfg.bias.hod, key))
-            model.set_parameter(key, param)
+                getattr(model, cfg.bias.hod.default_params)()
 
         # Check if 'seed' set
         if hasattr(cfg.bias.hod, 'seed'):
@@ -71,11 +66,20 @@ def parse_hod(cfg):
                 if cfg.bias.hod.seed == -1:
                     cfg.bias.hod.seed = np.random.randint(0, 1e5)
                 
-                # Set numpy seed
-                np.random.seed(cfg.bias.hod.seed)
-                
-                # Sample parameters from the HOD model
-                model.sample_parameters()
+                # If 0, don't change default values
+                if cfg.bias.hod.seed > 0:
+                    # Set numpy seed
+                    np.random.seed(cfg.bias.hod.seed)
+                    
+                    # Sample parameters from the HOD model
+                    model.sample_parameters()
+
+        # Overwrite any previously defined parameters
+        if hasattr(cfg.bias.hod, 'theta'):
+            for key in model.parameters:
+                if hasattr(cfg.bias.hod.theta, key):
+                    param = float(getattr(cfg.bias.hod.theta, key))
+                    model.set_parameter(key, param)
      
 
         # Get the parameter values

--- a/cmass/bias/tools/hod.py
+++ b/cmass/bias/tools/hod.py
@@ -99,6 +99,26 @@ def thetahod_literature(paper, model='zheng07'):
             }
         else:
             raise NotImplementedError
+    elif model == 'zu_mandelbaum15':
+        # if paper == 'zu_mandelbaum15':
+        """
+        Zu \& Mandelbaum+15, arXiv:1505.02781
+        Table 2, iHOD
+        """
+        p_hod = {
+            'smhm_m0': 10.31,
+            'smhm_m1': 12.10,
+            'smhm_beta': 0.33,
+            'smhm_delta': 0.42,
+            'smhm_gamma': 1.21,
+            'smhm_sigma': 0.50,
+            'smhm_sigma_slope': -0.04,
+            'alphasat': 1.00,
+            'betasat': 0.90,
+            'bsat': 8.98,
+            'betacut': 0.41,
+            'bcut': 0.86,
+        }
     else:
         raise ValueError(
             '`model` not recognised, please provide a supported HOD model:'

--- a/cmass/bias/tools/hod.py
+++ b/cmass/bias/tools/hod.py
@@ -26,8 +26,6 @@ from halotools.empirical_models import (
 )
 from halotools.empirical_models import HodModelFactory
 
-from ...utils import load_params
-
 
 def parse_hod(cfg):
     """

--- a/cmass/bias/tools/hod.py
+++ b/cmass/bias/tools/hod.py
@@ -1,5 +1,10 @@
+"""
+Tools for initilaising and implementing Halo Occupation 
+Distribution (HOD) models. 
+"""
 
 import numpy as np
+from omegaconf import open_dict
 
 from halotools.empirical_models import NFWProfile
 from halotools.sim_manager import UserSuppliedHaloCatalog
@@ -12,95 +17,334 @@ from halotools.empirical_models import (
 )
 from halotools.empirical_models import HodModelFactory
 
+from ...utils import load_params
 
-def thetahod_literature(paper, model='zheng07'):
-    ''' best-fit HOD parameters from the literature.
 
-    Currently, HOD values from the following papers are available:
-    * 'parejko2013_lowz'
-    * 'manera2015_lowz_ngc'
-    * 'manera2015_lowz_sgc'
-    * 'redi2014_cmass'
+def parse_hod(cfg):
+    """
+    Parse HOD parameters in the config file, and set them
+    in the `cfg` object
 
     Args:
-        model (str)
-            The HOD model for which we wish to obtain parameters
-        paper (str)
-            The paper of best-fit parameters
-    '''
-    if model == 'zheng07':
-        if paper == 'parejko2013_lowz':
-            # lowz catalog from Parejko+2013 Table 3. Note that the
-            # parameterization is slightly different so the numbers need to
-            # be converted.
-            p_hod = {
-                'logMmin': 13.25,
-                'sigma_logM': 0.43,  # 0.7 * sqrt(2) * log10(e)
-                'logM0': 13.27,  # log10(kappa * Mmin)
-                'logM1': 14.18,
-                'alpha': 0.94
-            }
-        elif paper == 'manera2015_lowz_ngc':
-            # best-fit HOD of the lowz catalog NGC from Table 2 of Manera et al.(2015)
-            p_hod = {
-                'logMmin': 13.20,
-                'sigma_logM': 0.62,
-                'logM0': 13.24,
-                'logM1': 14.32,
-                'alpha': 0.9
-            }
-        elif paper == 'manera2015_lowz_sgc':
-            # best-fit HOD of the lowz catalog SGC from Table 2 of Manera et al.(2015)
-            # Manera+(2015) actually uses a redshift dependent HOD. The HOD that's
-            # currently implemented is primarily for the 0.2 < z < 0.35 population,
-            # which has nbar~3x10^-4 h^3/Mpc^3
-            p_hod = {
-                'logMmin': 13.14,
-                'sigma_logM': 0.55,
-                'logM0': 13.43,
-                'logM1': 14.58,
-                'alpha': 0.93
-            }
-        elif paper == 'reid2014_cmass':
-            # best-fit HOD from Reid et al. (2014) Table 4
-            p_hod = {
-                'logMmin': 13.03,
-                'sigma_logM': 0.38,
-                'logM0': 13.27,
-                'logM1': 14.08,
-                'alpha': 0.76
-            }
+        cfg (object)
+            config object
+    Returns:
+        cfg (object)
+            modified config object
+    """
+    with open_dict(cfg):
+       
+        # First check model is available
+        if cfg.bias.hod.model == 'zheng07':
+            model = Zheng07()
+        elif cfg.bias.hod.model == 'leauthaud11':
+            model = Leauthaud11()
+        elif cfg.bias.hod.model == 'zu_mandelbaum15':
+            model = Zu_mandelbaum15()
         else:
             raise NotImplementedError
-    elif model == 'leauthaud11':
-        if paper == 'behroozi10':
-            """
-            Best-fit HOD from Behroozi+10 (arXiv:1001.0015; table 2, column 1) 
-            with redshift dependence, as well as bes fit satellite occupation
-            parameters from Leauthaud+12 (arXiv:1104.0928, Table 5, SIGMOD1).
-            """
-            p_hod = {
-                'smhm_m0_0': 10.72,
-                'smhm_m0_a': 0.55,
-                'smhm_m1_0': 12.35,
-                'smhm_m1_a': 0.28,
-                'smhm_beta_0': 0.44,
-                'smhm_beta_a': 0.18,
-                'smhm_delta_0': 0.57,
-                'smhm_delta_a': 0.17, 
-                'smhm_gamma_0': 1.56, 
-                'smhm_gamma_a': 2.51,
-                'scatter_model_param1': 0.15,
-                'alphasat': 1,
-                'betasat': 0.859,
-                'bsat': 10.62,
-                'betacut': -0.13,
-                'bcut': 1.47,
-            }
-        else:
-            raise NotImplementedError
-    elif model == 'zu_mandelbaum15':
-        # if paper == 'zu_mandelbaum15':
+
+        # Then check if we're using default parameters
+        if hasattr(cfg.bias.hod, 'param_defaults'):
+            if cfg.bias.hod.param_defaults is not None:
+                # Assign parameters given this default
+                getattr(model, cfg.bias.hod.param_defaults)()
+
+        # Update any additionally defined parameters
+        for key in model.parameters:
+            param = float(getattr(cfg.bias.hod, key))
+            model.set_parameter(key, param)
+
+        # Chek if 'seed' set
+        if hasattr(cfg.bias.hod, 'seed'):
+            if cfg.bias.hod.seed is not None:
+                # If -1, set to some random value
+                if cfg.bias.hod.seed == -1:
+                    cfg.bias.hod.seed = np.random.randint(0, 1e5)
+                
+                # Set numpy seed
+                np.random.seed(cfg.bias.hod.seed)
+                
+                # Sample parameters from the HOD model
+                model.sample_parameters()
+     
+
+        # Get the parameter values
+        cfg.bias.hod.theta = model.get_parameters()
+
+        # Cosmology
+        cfg.nbody.cosmo = load_params(
+            cfg.nbody.lhid, cfg.meta.cosmofile)
+
+    return cfg
+
+
+class Hod_parameter:
+    """
+    Helper class defining a HOD parameter, including the value
+    and upper and lower bounds (for a flat prior)
+    """
+    def __init__(self, key, value=None, upper=None, lower=None):
+        self.key = key
+        self.value = value
+        self.upper = upper
+        self.lower = lower
+
+
+class Hod_model:
+    """
+    Parent class defining a HOD model.
+    Includes methods for setting, getting and sampling parameters.
+    """
+    def __init__(self, parameters, lower_bound, upper_bound):
+        self.parameters = parameters
+
+        # Loop through parameters and initialise
+        for _param, _lower, _upper in zip(
+            self.parameters,
+            lower_bound,
+            upper_bound,
+        ):
+            setattr(
+                self,
+                _param,
+                Hod_parameter(
+                    key=_param,
+                    lower=_lower,
+                    upper=_upper
+                )
+            )
+
+    def set_parameter(self, key, new_parameter):
+        """
+        Set a single parameter
+        """
+        getattr(self, key).value = new_parameter
+
+    def set_parameters(self, new_parameters):
+        """
+        Set all parameters using a dict
+        """
+        for _param in self.parameters:
+            getattr(self, _param).value = new_parameters[_param]
+
+    def sample_parameters(self):
+        for _param in self.parameters:
+            # Get upper and lower bounds for this parameter
+            _lower = getattr(self, _param).lower
+            _upper = getattr(self, _param).upper
+
+            # Sample new parameter
+            sampled_param = np.random.uniform(_lower, _upper)
+
+            # Set new parameter
+            getattr(self, _param).value = sampled_param
+
+    def get_parameters(self):
+        """
+        Return a dict of parameter key / value pairs
+        """
+        out_params = {}
+        for _param in self.parameters:
+            out_params[_param] = getattr(self, _param).value
+
+        return out_params
+
+
+class Zheng07(Hod_model):
+    """
+    Zheng+07 HOD model
+    """
+    def __init__(
+        self,
+        parameters = ['logMmin', 'sigma_logM', 'logM0', 'logM1', 'alpha'],
+        lower_bound = np.array([12.0, 0.1, 13.0, 13.0, 0.]),
+        upper_bound = np.array([14.0, 0.6, 15.0, 15.0, 1.5]),
+        param_defaults=None
+    ):
+        super().__init__(parameters, lower_bound, upper_bound)
+
+        # If using, set literature values for parameters
+        self.param_defaults = param_defaults
+        if self.param_defaults is not None:
+            if self.param_defaults == 'parejko2013_lowz':
+                self.parejko2013_lowz()
+            elif self.param_defaults == 'manera2015_lowz_ngc':
+                self.manera2015_lowz_ngc()
+            elif self.param_defaults == 'manera2015_lowz_sgc':
+                self.manera2015_lowz_sgc()
+            elif self.param_defaults == 'reid2014_cmass':
+                self.reid2014_cmass()
+            else:
+                raise NotImplementedError
+
+
+    def parejko2013_lowz(self):
+        """
+        lowz catalog from Parejko+2013 Table 3. Note that the
+        parameterization is slightly different so the numbers need to
+        be converted.
+        """
+        p_hod = {
+            'logMmin': 13.25,
+            'sigma_logM': 0.43,  # 0.7 * sqrt(2) * log10(e)
+            'logM0': 13.27,  # log10(kappa * Mmin)
+            'logM1': 14.18,
+            'alpha': 0.94
+        }
+        self.set_parameters(p_hod)
+
+    def manera2015_lowz_ngc(self):
+        """
+        best-fit HOD of the lowz catalog NGC from Table 2 of Manera et al.(2015)
+        """
+        p_hod = {
+            'logMmin': 13.20,
+            'sigma_logM': 0.62,
+            'logM0': 13.24,
+            'logM1': 14.32,
+            'alpha': 0.9
+        }
+        self.set_parameters(p_hod)
+
+    def manera2015_lowz_sgc(self):
+        """
+        best-fit HOD of the lowz catalog SGC from Table 2 of Manera et al.(2015)
+        Manera+(2015) actually uses a redshift dependent HOD. The HOD that's
+        currently implemented is primarily for the 0.2 < z < 0.35 population,
+        which has nbar~3x10^-4 h^3/Mpc^3
+        """
+        p_hod = {
+            'logMmin': 13.14,
+            'sigma_logM': 0.55,
+            'logM0': 13.43,
+            'logM1': 14.58,
+            'alpha': 0.93
+        }
+        self.set_parameters(p_hod)
+
+    def reid2014_cmass(self):
+        """
+        best-fit HOD from Reid et al. (2014) Table 4
+        """
+        p_hod = {
+            'logMmin': 13.03,
+            'sigma_logM': 0.38,
+            'logM0': 13.27,
+            'logM1': 14.08,
+            'alpha': 0.76
+        }
+        self.set_parameters(p_hod)
+
+
+class Leauthaud11(Hod_model):
+    """
+    Leauthaud+11 HOD model
+    """
+    def __init__(
+        self,
+        parameters = [
+            'smhm_m0_0',
+            'smhm_m0_a',
+            'smhm_m1_0',
+            'smhm_m1_a',
+            'smhm_beta_0',
+            'smhm_beta_a',
+            'smhm_delta_0',
+            'smhm_delta_a',
+            'smhm_gamma_0',
+            'smhm_gamma_a',
+            'scatter_model_param1',
+            'alphasat',
+            'betasat',
+            'bsat',
+            'betacut',
+            'bcut'
+        ],
+        lower_bound = np.array([
+            10.0, -1.0, 12.0, -0.5, 0.3, -0.1, 0.5, -0.4, 1.0, 0.5, 0.1, 0, 0.5, 10.0, -0.2, 1.0,
+        ]),
+        upper_bound = np.array([
+            11.0, 1.0, 13.0, 0.8, 0.6, 0.4, 0.8, 0.6, 1.8, 3.0, 0.2, 1.5, 1.3, 11.0, 0.1, 2.0,
+        ]),
+        param_defaults=None
+    ):
+        super().__init__(parameters, lower_bound, upper_bound)
+
+        # If using, set literature values for parameters
+        self.param_defaults = param_defaults
+        if self.param_defaults is not None:
+            if self.param_defaults == 'behroozi10':
+                self.behroozi10()
+            else:
+                raise NotImplementedError
+
+    def behroozi10(self):
+        """
+        Best-fit HOD from Behroozi+10 (arXiv:1001.0015; table 2, column 1) 
+        with redshift dependence, as well as bes fit satellite occupation
+        parameters from Leauthaud+12 (arXiv:1104.0928, Table 5, SIGMOD1).
+        """
+        p_hod = {
+            'smhm_m0_0': 10.72,
+            'smhm_m0_a': 0.55,
+            'smhm_m1_0': 12.35,
+            'smhm_m1_a': 0.28,
+            'smhm_beta_0': 0.44,
+            'smhm_beta_a': 0.18,
+            'smhm_delta_0': 0.57,
+            'smhm_delta_a': 0.17, 
+            'smhm_gamma_0': 1.56, 
+            'smhm_gamma_a': 2.51,
+            'scatter_model_param1': 0.15,
+            'alphasat': 1,
+            'betasat': 0.859,
+            'bsat': 10.62,
+            'betacut': -0.13,
+            'bcut': 1.47,
+        }
+        self.set_parameters(p_hod)
+    
+class Zu_mandelbaum15(Hod_model):
+    """
+    Zu & Mandelbaum+15 HOD model
+    """
+    def __init__(
+        self,
+        parameters = [
+            'smhm_m0',
+            'smhm_m1',
+            'smhm_beta',
+            'smhm_delta',
+            'smhm_gamma',
+            'smhm_sigma',
+            'smhm_sigma_slope',
+            'alphasat',
+            'betasat',
+            'bsat',
+            'betacut',
+            'bcut',
+        ],
+        lower_bound = np.array([
+            9.0, 9.5, 0.0, 0.0, -0.1, 0.01, -0.4, 0.5, 0.1, 0.01, -0.05, 0.0,
+        ]),
+        upper_bound = np.array([
+            13.0, 14.0, 2.0, 1.5, 4.9, 3.0, 0.4, 1.5, 1.8, 25.0, 1.50, 6.0, 
+        ]),
+        param_defaults=None
+    ):
+        super().__init__(parameters, lower_bound, upper_bound)
+
+        # If using, set literature values for parameters
+        self.param_defaults = param_defaults
+        if self.param_defaults is not None:
+            if self.param_defaults == 'zu_mandelbaum15':
+                self.behroozi10()
+            else:
+                raise NotImplementedError
+
+    
+    def zu_mandelbaum15(self):
         """
         Zu \& Mandelbaum+15, arXiv:1505.02781
         Table 2, iHOD
@@ -119,13 +363,7 @@ def thetahod_literature(paper, model='zheng07'):
             'betacut': 0.41,
             'bcut': 0.86,
         }
-    else:
-        raise ValueError(
-            '`model` not recognised, please provide a supported HOD model:'
-            ' zheng07, leauthaud11, zu_mandelbaum15' 
-        )
-
-    return p_hod
+        self.set_parameters(p_hod)
 
 
 def mass_to_concentration(mass, redshift, cosmo, mdef='vir'):
@@ -199,18 +437,17 @@ def build_halo_catalog(
 
 
 def build_HOD_model(
-    cosmology, redshift, hod_model='zheng07', mdef='vir', **hod_params
+    cosmology, cfg, mdef='vir',
 ):
     '''Build a HOD model from the given HOD parameters.
 
     Args:
         cosmology (astropy.cosmology.Cosmology):
             The cosmology used for the simulation.
-        redshift (float): The redshift of the halo catalog.
-        hod_model (str, optional): The HOD model to use.
-            Defaults to 'zheng07'.
-        mdef (str, optional): Halo mass definition. Defaults to 'vir'.
-        **kwargs: Additional arguments to pass to the HOD model.
+        cfg (cfg object):
+            Configuration dict object.
+        mdef (str, optional):
+            Halo mass definition. Defaults to 'vir'.
 
     Returns:
         hod_model (HODMockFactory): A HOD model object
@@ -219,22 +456,16 @@ def build_HOD_model(
     # determine mass column
     mkey = 'halo_m' + mdef
 
-    # parse HOD parameters
-    if hod_model == 'zheng07':
-        t_ = thetahod_literature('manera2015_lowz_ngc', hod_model)
-    elif hod_model == 'leauthaud11':
-        t_ = thetahod_literature('behroozi10', hod_model)
-    else:
-        raise ValueError('`hod_model` not recognised.')
+    # Get HOD parameters
+    hod_params = dict(cfg.bias.hod.theta)
+    hod_params.update({
+        'cosmology': cosmology,
+        'redshift': cfg.nbody.zf,
+        'mdef': mdef,
+    })
 
-    t_.update(hod_params)
-    hod_params = t_
-    
-    hod_params.update(
-        {'cosmology': cosmology, 'redshift': redshift, 'mdef': mdef})
-
-    # occupation functions
-    if hod_model == 'zheng07':
+    # Occupation functions
+    if cfg.bias.hod.model == 'zheng07':
         cenocc = Zheng07Cens(prim_haloprop_key=mkey, **hod_params)
         satocc = Zheng07Sats(
             prim_haloprop_key=mkey,
@@ -242,14 +473,14 @@ def build_HOD_model(
             modulate_with_cenocc=True,
             **hod_params
         )
-    elif hod_model == 'leauthaud11':
+    elif cfg.bias.hod.model == 'leauthaud11':
         cenocc = Leauthaud11Cens(prim_haloprop_key=mkey, **hod_params)
         satocc = Leauthaud11Sats(
             prim_haloprop_key=mkey,
             cenocc_model=cenocc,
             **hod_params
         )
-    elif hod_model == 'zu_mandelbaum15':
+    elif cfg.bias.hod.model == 'zu_mandelbaum15':
         cenocc = ZuMandelbaum15Cens(prim_haloprop_key=mkey, **hod_params)
         satocc = ZuMandelbaum15Sats(
             prim_haloprop_key=mkey,

--- a/cmass/bias/tools/hod.py
+++ b/cmass/bias/tools/hod.py
@@ -4,11 +4,16 @@ import numpy as np
 from halotools.empirical_models import NFWProfile
 from halotools.sim_manager import UserSuppliedHaloCatalog
 from halotools.empirical_models import halo_mass_to_halo_radius
-from halotools.empirical_models import Zheng07Sats, Zheng07Cens, NFWPhaseSpace, TrivialPhaseSpace
+from halotools.empirical_models import (
+    Zheng07Cens, Zheng07Sats,
+    Leauthaud11Cens, Leauthaud11Sats,
+    ZuMandelbaum15Cens, ZuMandelbaum15Sats,
+    NFWPhaseSpace, TrivialPhaseSpace,
+)
 from halotools.empirical_models import HodModelFactory
 
 
-def thetahod_literature(paper):
+def thetahod_literature(paper, model='zheng07'):
     ''' best-fit HOD parameters from the literature.
 
     Currently, HOD values from the following papers are available:
@@ -16,50 +21,89 @@ def thetahod_literature(paper):
     * 'manera2015_lowz_ngc'
     * 'manera2015_lowz_sgc'
     * 'redi2014_cmass'
+
+    Args:
+        model (str)
+            The HOD model for which we wish to obtain parameters
+        paper (str)
+            The paper of best-fit parameters
     '''
-    if paper == 'parejko2013_lowz':
-        # lowz catalog from Parejko+2013 Table 3. Note that the
-        # parameterization is slightly different so the numbers need to
-        # be converted.
-        p_hod = {
-            'logMmin': 13.25,
-            'sigma_logM': 0.43,  # 0.7 * sqrt(2) * log10(e)
-            'logM0': 13.27,  # log10(kappa * Mmin)
-            'logM1': 14.18,
-            'alpha': 0.94
-        }
-    elif paper == 'manera2015_lowz_ngc':
-        # best-fit HOD of the lowz catalog NGC from Table 2 of Manera et al.(2015)
-        p_hod = {
-            'logMmin': 13.20,
-            'sigma_logM': 0.62,
-            'logM0': 13.24,
-            'logM1': 14.32,
-            'alpha': 0.9
-        }
-    elif paper == 'manera2015_lowz_sgc':
-        # best-fit HOD of the lowz catalog SGC from Table 2 of Manera et al.(2015)
-        # Manera+(2015) actually uses a redshift dependent HOD. The HOD that's
-        # currently implemented is primarily for the 0.2 < z < 0.35 population,
-        # which has nbar~3x10^-4 h^3/Mpc^3
-        p_hod = {
-            'logMmin': 13.14,
-            'sigma_logM': 0.55,
-            'logM0': 13.43,
-            'logM1': 14.58,
-            'alpha': 0.93
-        }
-    elif paper == 'reid2014_cmass':
-        # best-fit HOD from Reid et al. (2014) Table 4
-        p_hod = {
-            'logMmin': 13.03,
-            'sigma_logM': 0.38,
-            'logM0': 13.27,
-            'logM1': 14.08,
-            'alpha': 0.76
-        }
+    if model == 'zheng07':
+        if paper == 'parejko2013_lowz':
+            # lowz catalog from Parejko+2013 Table 3. Note that the
+            # parameterization is slightly different so the numbers need to
+            # be converted.
+            p_hod = {
+                'logMmin': 13.25,
+                'sigma_logM': 0.43,  # 0.7 * sqrt(2) * log10(e)
+                'logM0': 13.27,  # log10(kappa * Mmin)
+                'logM1': 14.18,
+                'alpha': 0.94
+            }
+        elif paper == 'manera2015_lowz_ngc':
+            # best-fit HOD of the lowz catalog NGC from Table 2 of Manera et al.(2015)
+            p_hod = {
+                'logMmin': 13.20,
+                'sigma_logM': 0.62,
+                'logM0': 13.24,
+                'logM1': 14.32,
+                'alpha': 0.9
+            }
+        elif paper == 'manera2015_lowz_sgc':
+            # best-fit HOD of the lowz catalog SGC from Table 2 of Manera et al.(2015)
+            # Manera+(2015) actually uses a redshift dependent HOD. The HOD that's
+            # currently implemented is primarily for the 0.2 < z < 0.35 population,
+            # which has nbar~3x10^-4 h^3/Mpc^3
+            p_hod = {
+                'logMmin': 13.14,
+                'sigma_logM': 0.55,
+                'logM0': 13.43,
+                'logM1': 14.58,
+                'alpha': 0.93
+            }
+        elif paper == 'reid2014_cmass':
+            # best-fit HOD from Reid et al. (2014) Table 4
+            p_hod = {
+                'logMmin': 13.03,
+                'sigma_logM': 0.38,
+                'logM0': 13.27,
+                'logM1': 14.08,
+                'alpha': 0.76
+            }
+        else:
+            raise NotImplementedError
+    elif model == 'leauthaud11':
+        if paper == 'behroozi10':
+            """
+            Best-fit HOD from Behroozi+10 (arXiv:1001.0015; table 2, column 1) 
+            with redshift dependence, as well as bes fit satellite occupation
+            parameters from Leauthaud+12 (arXiv:1104.0928, Table 5, SIGMOD1).
+            """
+            p_hod = {
+                'smhm_m0_0': 10.72,
+                'smhm_m0_a': 0.55,
+                'smhm_m1_0': 12.35,
+                'smhm_m1_a': 0.28,
+                'smhm_beta_0': 0.44,
+                'smhm_beta_a': 0.18,
+                'smhm_delta_0': 0.57,
+                'smhm_delta_a': 0.17, 
+                'smhm_gamma_0': 1.56, 
+                'smhm_gamma_a': 2.51,
+                'scatter_model_param1': 0.15,
+                'alphasat': 1,
+                'betasat': 0.859,
+                'bsat': 10.62,
+                'betacut': -0.13,
+                'bcut': 1.47,
+            }
+        else:
+            raise NotImplementedError
     else:
-        raise NotImplementedError
+        raise ValueError(
+            '`model` not recognised, please provide a supported HOD model:'
+            ' zheng07, leauthaud11, zu_mandelbaum15' 
+        )
 
     return p_hod
 
@@ -156,24 +200,47 @@ def build_HOD_model(
     mkey = 'halo_m' + mdef
 
     # parse HOD parameters
-    t_ = thetahod_literature('manera2015_lowz_ngc')
+    if hod_model == 'zheng07':
+        t_ = thetahod_literature('manera2015_lowz_ngc', hod_model)
+    elif hod_model == 'leauthaud11':
+        t_ = thetahod_literature('behroozi10', hod_model)
+    else:
+        raise ValueError('`hod_model` not recognised.')
+
     t_.update(hod_params)
     hod_params = t_
+    
+    hod_params.update(
+        {'cosmology': cosmology, 'redshift': redshift, 'mdef': mdef})
 
     # occupation functions
     if hod_model == 'zheng07':
         cenocc = Zheng07Cens(prim_haloprop_key=mkey, **hod_params)
         satocc = Zheng07Sats(
             prim_haloprop_key=mkey,
-            cenocc_model=cenocc, **hod_params
+            cenocc_model=cenocc,
+            modulate_with_cenocc=True,
+            **hod_params
         )
+    elif hod_model == 'leauthaud11':
+        cenocc = Leauthaud11Cens(prim_haloprop_key=mkey, **hod_params)
+        satocc = Leauthaud11Sats(
+            prim_haloprop_key=mkey,
+            cenocc_model=cenocc,
+            **hod_params
+        )
+    elif hod_model == 'zu_mandelbaum15':
+        cenocc = ZuMandelbaum15Cens(prim_haloprop_key=mkey, **hod_params)
+        satocc = ZuMandelbaum15Sats(
+            prim_haloprop_key=mkey,
+            cenocc_model=cenocc,
+            **hod_params
+        )                
     else:
         raise NotImplementedError
     satocc._suppress_repeated_param_warning = True
 
     # profile functions
-    hod_params.update(
-        {'cosmology': cosmology, 'redshift': redshift, 'mdef': mdef})
     censprof = TrivialPhaseSpace(**hod_params)
     satsprof = NFWPhaseSpace(**hod_params)
 

--- a/cmass/bias/tools/hod.py
+++ b/cmass/bias/tools/hod.py
@@ -450,15 +450,18 @@ def build_halo_catalog(
 
 
 def build_HOD_model(
-    cosmology, cfg, mdef='vir',
+    cosmology, model, theta, mdef='vir',
 ):
     '''Build a HOD model from the given HOD parameters.
 
     Args:
         cosmology (astropy.cosmology.Cosmology):
             The cosmology used for the simulation.
-        cfg (cfg object):
-            Configuration dict object.
+        model (str): The HOD model to use. Options are:
+            - 'zheng07'
+            - 'leauthaud11'
+            - 'zu_mandelbaum15'
+        theta (dict): The HOD parameters.
         mdef (str, optional):
             Halo mass definition. Defaults to 'vir'.
 
@@ -470,7 +473,7 @@ def build_HOD_model(
     mkey = 'halo_m' + mdef
 
     # Get HOD parameters
-    hod_params = dict(cfg.bias.hod.theta)
+    hod_params = dict(theta)
     hod_params.update({
         'cosmology': cosmology,
         'redshift': cfg.nbody.zf,
@@ -478,7 +481,7 @@ def build_HOD_model(
     })
 
     # Occupation functions
-    if cfg.bias.hod.model == 'zheng07':
+    if model == 'zheng07':
         cenocc = Zheng07Cens(prim_haloprop_key=mkey, **hod_params)
         satocc = Zheng07Sats(
             prim_haloprop_key=mkey,
@@ -486,14 +489,14 @@ def build_HOD_model(
             modulate_with_cenocc=True,
             **hod_params
         )
-    elif cfg.bias.hod.model == 'leauthaud11':
+    elif model == 'leauthaud11':
         cenocc = Leauthaud11Cens(prim_haloprop_key=mkey, **hod_params)
         satocc = Leauthaud11Sats(
             prim_haloprop_key=mkey,
             cenocc_model=cenocc,
             **hod_params
         )
-    elif cfg.bias.hod.model == 'zu_mandelbaum15':
+    elif model == 'zu_mandelbaum15':
         cenocc = ZuMandelbaum15Cens(prim_haloprop_key=mkey, **hod_params)
         satocc = ZuMandelbaum15Sats(
             prim_haloprop_key=mkey,

--- a/cmass/bias/tools/hod.py
+++ b/cmass/bias/tools/hod.py
@@ -44,7 +44,9 @@ def parse_hod(cfg):
     with open_dict(cfg):
        
         # First check model is available
-        if cfg.bias.hod.model == 'zheng07':
+        if not hasattr(cfg.bias.hod, 'model'):
+            model = Zheng07()  # for backwards compatibility
+        elif cfg.bias.hod.model == 'zheng07':
             model = Zheng07()
         elif cfg.bias.hod.model == 'leauthaud11':
             model = Leauthaud11()
@@ -84,10 +86,12 @@ def parse_hod(cfg):
 
         # Get the parameter values
         cfg.bias.hod.theta = model.get_parameters()
-
-        # Cosmology
-        cfg.nbody.cosmo = load_params(
-            cfg.nbody.lhid, cfg.meta.cosmofile)
+        
+        # Check if any values are None
+        for k, v in cfg.bias.hod.theta.items():
+            if v is None:
+                raise ValueError(f'Parameter {k} is None. Make sure to '
+                                 'set default parameters or hod.seed>0.')
 
     return cfg
 

--- a/cmass/bias/tools/hod.py
+++ b/cmass/bias/tools/hod.py
@@ -1,6 +1,15 @@
 """
 Tools for initilaising and implementing Halo Occupation 
-Distribution (HOD) models. 
+Distribution (HOD) models.
+
+Currently implemented models:
+- Zheng+07
+- Leauthaud+11
+- Zu & Mandelbaum+15
+
+Each model derives from the `Hod_model` parent class,
+which additionally uses the `Hod_parameter` helper class
+for each parameter.
 """
 
 import numpy as np

--- a/cmass/conf/bias/cic_hod.yaml
+++ b/cmass/conf/bias/cic_hod.yaml
@@ -28,14 +28,16 @@ hod:
   # available defaults for each model.
   default_params: 'reid2014_cmass' 
   
-  # HOD seed. If `null` or 0, use parameters below.
+  # HOD seed. If `null` or 0, use default parameters.
   # If -1, set random seed.
-  seed: 2
+  # Else, randomly set parameters with the given seed.
+  seed: 0
 
-  # Custom parameters for the Zheng+07 model. Will
-  # overwrite any defaults set above.
-  logMmin: 13.0    # log10(Mmin) in Msun/h
-  sigma_logM: 0.2  # scatter in log10(Mmin)
-  logM0: 14.0      # log10(M0) in Msun/h
-  logM1: 14.0      # log10(M1) in Msun/h
-  alpha: 1.0       # slope of the power-law mass function
+# Custom parameters for the Zheng+07 model.
+# These will overwrite any defaults set above.
+  theta:
+  #   logMmin: 13.0    # log10(Mmin) in Msun/h
+  #   sigma_logM: 0.2  # scatter in log10(Mmin)
+  #   logM0: 14.0      # log10(M0) in Msun/h
+  #   logM1: 14.0      # log10(M1) in Msun/h
+  #   alpha: 1.0       # slope of the power-law mass function

--- a/cmass/conf/bias/cic_hod.yaml
+++ b/cmass/conf/bias/cic_hod.yaml
@@ -15,8 +15,25 @@ halo:
   vel: "CIC"
 
 # galaxy biasing
-hod: 
-  seed: 0       # HOD seed (if null, use below parameters)
+hod:
+  # Set HOD model. Can be one of:
+  # - zheng07
+  # - leauthaud11
+  # - zu_mandelbaum15
+  model: 'zheng07'
+  
+  # Set default parameters from a given reference. 
+  # Any parameters set explicitly here will overwrite
+  # these defaults. Check cmass/bias/tools/hod.py for 
+  # available defaults for each model.
+  default_params: 'reid2014_cmass' 
+  
+  # HOD seed. If `null` or 0, use parameters below.
+  # If -1, set random seed.
+  seed: 2
+
+  # Custom parameters for the Zheng+07 model. Will
+  # overwrite any defaults set above.
   logMmin: 13.0    # log10(Mmin) in Msun/h
   sigma_logM: 0.2  # scatter in log10(Mmin)
   logM0: 14.0      # log10(M0) in Msun/h

--- a/cmass/conf/diag/default.yaml
+++ b/cmass/conf/diag/default.yaml
@@ -16,7 +16,9 @@ summaries:
 
 # whether to use abundance matching to affix number density
 halo_density: 1e-4  # number density in h^3/Mpc^3. null for no abundance matching
-halo_proxy: mass  # property for abundance matching
+halo_proxy: mass  # property for abundance matching (null for no abundance matching)
 
 galaxy_density: null  # number density in h^3/Mpc^3. null for no abundance matching
-galaxy_proxy: mstar  # property for abundance matching
+galaxy_proxy: null  # property for abundance matching (null for no abundance matching)
+
+# Note, we don't have a mass proxy for galaxies, so we can't use abundance matching

--- a/cmass/diagnostics/summ.py
+++ b/cmass/diagnostics/summ.py
@@ -179,7 +179,7 @@ def summarize_rho(source_path, L, threads=16, from_scratch=True):
 
 def summarize_tracer(
     source_path, L, N, h,
-    density=None, proxy='mass',
+    density=None, proxy=None,
     threads=16, from_scratch=True,
     type='halo', hod_seed=None,
     summaries=['Pk']
@@ -226,14 +226,20 @@ def summarize_tracer(
                 # Mask out low mass tracers (to match number density)
                 mass = None
                 if density is not None:
-                    if proxy not in f[a].keys():
-                        logging.error(
-                            f'{proxy} not found in {type} file at a={a}')
-                    if len(pos) <= Ncut:
-                        logging.warning(f'Not enough {type} tracers in {a}')
-                    logging.info(
-                        f'Cutting top {Ncut} out of {len(pos)} {type} tracers to match number density')
-                    mass = f[a][proxy][...].astype(np.float32)
+                    if proxy is None:
+                        logging.warning('Proxy is set to None. Not rank-ordering.')
+                        mass = np.arange(len(pos))
+                        np.random.shuffle(mass)
+                    else:
+                        if proxy not in f[a].keys():
+                            logging.error(
+                                f'{proxy} not found in {type} file at a={a}')
+                        if len(pos) <= Ncut:
+                            logging.warning(f'Not enough {type} tracers in {a}')
+                        logging.info(
+                            f'Cutting top {Ncut} out of {len(pos)} {type} tracers '
+                            'to match number density')
+                        mass = f[a][proxy][...].astype(np.float32)
                     mask = np.argsort(mass)[-Ncut:]  # Keep top Ncut tracers
                     pos = pos[mask]
                     vel = vel[mask]


### PR DESCRIPTION
Updates the HOD prescription with two new models (Leauthaud+11,  Zu & Mandelbaum+15), and rewrites the configuration for ease of use.

Users now define everything in `cmass/conf/bias/your_bias_config_file.py` as follows:

    # galaxy biasing
    hod:
      # Set HOD model. Can be one of:
      # - zheng07
      # - leauthaud11
      # - zu_mandelbaum15
      model: 'zheng07'
    
      # Set default parameters from a given reference. 
      # Any parameters set explicitly here will overwrite
      # these defaults. Check cmass/bias/tools/hod.py for 
      # available defaults for each model.
      default_params: 'reid2014_cmass'
    
      # HOD seed. If `null` or 0, use parameters below.
      # If -1, set random seed.
      seed: 2
    
      # Custom parameters for the Zheng+07 model. Will
      # overwrite any defaults set above.
      logMmin: 13.0    # log10(Mmin) in Msun/h
      sigma_logM: 0.2  # scatter in log10(Mmin)
      logM0: 14.0      # log10(M0) in Msun/h
      logM1: 14.0      # log10(M1) in Msun/h
      alpha: 1.0       # slope of the power-law mass function


Implements some of the functionality detailed in #63.