### PR TITLE
Adds abundance matching to the `diagnostics` module

### DIFF
--- a/cmass/conf/diag/default.yaml
+++ b/cmass/conf/diag/default.yaml
@@ -4,3 +4,10 @@ from_scratch: true
 
 # number of threads for P(k) computation
 threads: 16
+
+# whether to use abundance matching to affix number density
+halo_density: 1e-3  # number density in h^3/Mpc^3, None for no abundance matching
+halo_proxy: M200c  # property for abundance matching
+
+galaxy_density: 1e-4  # number density in h^3/Mpc^3, None for no abundance matching
+galaxy_proxy: mstar  # property for abundance matching

--- a/cmass/conf/diag/default.yaml
+++ b/cmass/conf/diag/default.yaml
@@ -15,8 +15,8 @@ summaries:
     # - Density Split  # density split statistics
 
 # whether to use abundance matching to affix number density
-halo_density: 1e-3  # number density in h^3/Mpc^3, None for no abundance matching
+halo_density: 1e-4  # number density in h^3/Mpc^3. None for no abundance matching
 halo_proxy: M200c  # property for abundance matching
 
-galaxy_density: 1e-4  # number density in h^3/Mpc^3, None for no abundance matching
+galaxy_density: 2e-4  # number density in h^3/Mpc^3. None for no abundance matching
 galaxy_proxy: mstar  # property for abundance matching

--- a/cmass/conf/diag/default.yaml
+++ b/cmass/conf/diag/default.yaml
@@ -3,7 +3,7 @@
 from_scratch: true
 
 # number of threads for P(k) computation
-threads: 16
+threads: -1  # -1 for all available threads
 
 # which summaries to run
 summaries:
@@ -16,7 +16,7 @@ summaries:
 
 # whether to use abundance matching to affix number density
 halo_density: 1e-4  # number density in h^3/Mpc^3. None for no abundance matching
-halo_proxy: M200c  # property for abundance matching
+halo_proxy: mass  # property for abundance matching
 
 galaxy_density: 2e-4  # number density in h^3/Mpc^3. None for no abundance matching
 galaxy_proxy: mstar  # property for abundance matching

--- a/cmass/conf/diag/default.yaml
+++ b/cmass/conf/diag/default.yaml
@@ -1,5 +1,5 @@
 
-# whether to calculate diagnostics from scratch, if already saved
+# whether to calculate diagnostics from scratch, overwriting existing files
 from_scratch: true
 
 # number of threads for P(k) computation

--- a/cmass/conf/diag/default.yaml
+++ b/cmass/conf/diag/default.yaml
@@ -5,6 +5,15 @@ from_scratch: true
 # number of threads for P(k) computation
 threads: 16
 
+# which summaries to run
+summaries:
+    - Pk             # power spectrum
+    # - TwoPCF         # two-point correlation function
+    # - KNN            # k-nearest neighbors
+    # - WST            # wavelet scattering transform
+    # - Bk             # bispectrum
+    # - Density Split  # density split statistics
+
 # whether to use abundance matching to affix number density
 halo_density: 1e-3  # number density in h^3/Mpc^3, None for no abundance matching
 halo_proxy: M200c  # property for abundance matching

--- a/cmass/conf/diag/default.yaml
+++ b/cmass/conf/diag/default.yaml
@@ -15,8 +15,8 @@ summaries:
     # - Density Split  # density split statistics
 
 # whether to use abundance matching to affix number density
-halo_density: 1e-4  # number density in h^3/Mpc^3. None for no abundance matching
+halo_density: 1e-4  # number density in h^3/Mpc^3. null for no abundance matching
 halo_proxy: mass  # property for abundance matching
 
-galaxy_density: 2e-4  # number density in h^3/Mpc^3. None for no abundance matching
+galaxy_density: null  # number density in h^3/Mpc^3. null for no abundance matching
 galaxy_proxy: mstar  # property for abundance matching

--- a/cmass/conf/nbody/abacuslike.yaml
+++ b/cmass/conf/nbody/abacuslike.yaml
@@ -1,0 +1,35 @@
+# for calibrating halo biasing models with quijote
+suite: abacuslike
+
+# General parameters
+L: 2000           # Mpc/h
+N: 256            # meshgrid resolution
+lhid: 3           # latin hypercube id
+matchIC: 0        # whether to match ICs to file (0 no, 1 yes, 2 quijote)
+supersampling: 3  # particles resolution relative to meshgrid
+save_particles: false  # whether to save particle data
+save_transfer: True    # whether to save z=99 ICs (for CHARM bias model)
+
+zi: 10            # initial redshift (for grav solver)
+zf: 0.3           # final redshift
+
+# snapshot scale factors to save (e.g. evenly spaced in a)
+# asave: []
+asave: [0.58622, 0.60633, 0.62644, 0.64655, 0.66666, 0.68677, 0.70688, 0.72699, 0.74710, 0.76721]
+
+
+# borglpt, borgpm and pinocchio-only
+transfer: 'CAMB' # transfer function (EH, CLASS, CAMB or SYREN. Only EH or CLASS for borg)
+
+# borglpt-only
+order: 2          # order of the LPT expansion
+
+# pmwd, fastpm, borgpm-only
+B: 2              # force grid resolution relative to particle grid
+N_steps: 32       # number of PM integration steps
+
+# borgpm-only
+COLA: true        # whether to use COLA
+
+# pinocchio only
+mass_function: Watson_2013  # which output HMF to use

--- a/cmass/diagnostics/summ.py
+++ b/cmass/diagnostics/summ.py
@@ -18,11 +18,6 @@ from ..utils import get_source_path, timing_decorator
 from ..nbody.tools import parse_nbody_config
 from .tools import MA, MAz, calcPk, get_redshift_space_pos
 
-# check if we're running on anvil
-import socket
-if 'anvil' in socket.gethostname():
-    os.environ['LD_PRELOAD'] = '/usr/lib64/libslurm.so'
-
 
 def get_box_catalogue(pos, z, L, N):
     return BoxCatalogue(
@@ -138,14 +133,18 @@ def store_summary(
     catalog, group, summary_name,
     box_size, num_bins, num_threads, use_rsd=False
 ):
+    # get summary binning
     binning_config = get_binning(
         summary_name, box_size, num_bins, num_threads, rsd=use_rsd)
 
     logging.info(f'Computing Summary: {summary_name}, with binning:')
     logging.info(binning_config)
 
+    # compute summary
     summary_function = getattr(summarizer, summary_name)(**binning_config)
     summary_data = summary_function(catalog)
+
+    # store summary
     summary_dataset = summary_function.to_dataset(summary_data)
     for coord_name, coord_value in summary_dataset.coords.items():
         dataset_key = f"{'z' if use_rsd else ''}{summary_name}_{coord_name}"

--- a/cmass/diagnostics/summ.py
+++ b/cmass/diagnostics/summ.py
@@ -217,6 +217,9 @@ def summarize_tracer(
                 vel = f[a]['vel'][...].astype(np.float32)
                 pos %= L  # Ensure all tracers inside box
 
+                # Create output group
+                group = o.create_group(a)
+
                 # Mask out low mass tracers (to match number density)
                 mass = None
                 if density is not None:
@@ -224,16 +227,16 @@ def summarize_tracer(
                         logging.error(f'{proxy} not found in {type} file at a={a}')
                     if len(pos) <= Ncut:
                         logging.warning(f'Not enough {type} tracers in {a}')
-                    logging.warning(f'Cutting top {Ncut} out of {len(pos)} {type} tracers to match number density')
+                    logging.info(f'Cutting top {Ncut} out of {len(pos)} {type} tracers to match number density')
                     mass = f[a][proxy][...].astype(np.float32)
                     mask = np.argsort(mass)[-Ncut:]  # Keep top Ncut tracers
                     pos = pos[mask]
                     vel = vel[mask]
                     mass = mass[mask]
 
-                # Create output group
-                group = o.create_group(a)
-                group.attrs['density'] = density
+                    group.attrs['density'] = float(density)
+                else:
+                    group.attrs['density'] = np.nan
 
                 # Compute P(k)
                 if 'Pk' in summaries:

--- a/cmass/diagnostics/tools.py
+++ b/cmass/diagnostics/tools.py
@@ -3,6 +3,7 @@ import Pk_library as PKL
 import MAS_library as MASL
 import redshift_space_library as RSL
 
+
 def get_redshift_space_pos(pos, vel, L, h, z, axis=0):
     pos, vel = map(np.ascontiguousarray, (pos, vel))
     RSL.pos_redshift_space(pos, vel, L, h*100, z, axis)

--- a/cmass/diagnostics/tools.py
+++ b/cmass/diagnostics/tools.py
@@ -30,3 +30,17 @@ def calcPk(delta, L, axis=0, MAS='CIC', threads=16):
     k = Pk.k3D
     Pk = Pk.Pk
     return k, Pk
+
+def get_box_catalogue(pos, z, L, N):
+    from summarizer.data import BoxCatalogue  # only import if needed
+
+    return BoxCatalogue(
+        galaxies_pos=pos,
+        redshift=z,
+        boxsize=L,
+        n_mesh=N,
+    )
+
+def get_box_catalogue_rsd(pos, vel, z, L, h, axis, N):
+    pos = get_redshift_space_pos(pos=pos, vel=vel, z=z, h=h, axis=axis, L=L,)
+    return get_box_catalogue(pos, z, L, N)

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -143,6 +143,7 @@ You can see other default configurations in [`cmass/conf`](../cmass/conf).
 
 We include various additional functionality beyond the minimal working example above. These are provided in separate documentation, including:
 - [Installing `pmesh` and running pypower](./options/PMESH.md)
+- [Installing ili-summarizer](./options/SUMMARIZER.md)
 - [Running with Quijote initial conditions and fitting bias models](./options/QUIJOTE.md)
 - [Installing and running FASTPM nbody simulators](./options/FASTPM.md)
 - [Installing and running BORG nbody simulators](./options/BORG.md)


### PR DESCRIPTION
This PR adds functionality to abundance-match the most massive galaxies in each simulation. This is to help compare simulations which may not have the same mass definitions, but have similar proxies.

Key additions:
- cmass/conf/diag/default.yaml now includes halo_density/proxy and galaxy_density/proxy, which allows users to specify what tracer number density they want to include. Densities are specified in units of 1/volume. For example, the top N=L^3*galaxy_density galaxies sorted by galaxy_proxy are used to calculate the diagnostic summaries.

Also:
- Adds configuration of which summaries to run in cmass/conf/diag/default.yaml
- Adds a reference to SUMMARIZER.md in INSTALL.md
- Pulls abacuslike.yaml into the main branch from runanvil
- The default P(k) backend is now Pylians instead of ili-summarizer. This is for when ili-summarizer fails to install
- Ran PEP linter
- Merged halo and gal_summ functions into summarize_tracer
- Added more informative logging
- Default threads now use all CPUs