### PR TITLE
Update all scripts to use the `cfg.multisnapshot` flag to control when to run more than one snapshot

### DIFF
--- a/cmass/bias/apply_hod.py
+++ b/cmass/bias/apply_hod.py
@@ -138,7 +138,8 @@ def save_snapshot(outpath, a, gpos, gvel, **meta):
 @ hydra.main(version_base=None, config_path="../conf", config_name="config")
 def main(cfg: DictConfig) -> None:
     # Filtering for necessary configs
-    cfg = OmegaConf.masked_copy(cfg, ['meta', 'sim', 'nbody', 'bias'])
+    cfg = OmegaConf.masked_copy(
+        cfg, ['meta', 'sim', 'multisnapshot', 'nbody', 'bias'])
 
     # Build run config
     cfg = parse_nbody_config(cfg)

--- a/cmass/bias/fit_halo_bias.py
+++ b/cmass/bias/fit_halo_bias.py
@@ -116,7 +116,8 @@ def save_bias(source_path, a, medges, popt):
 @hydra.main(version_base=None, config_path="../conf", config_name="config")
 def main(cfg: DictConfig) -> None:
     # Filtering for necessary configs
-    cfg = OmegaConf.masked_copy(cfg, ['meta', 'sim', 'nbody', 'fit'])
+    cfg = OmegaConf.masked_copy(
+        cfg, ['meta', 'sim', 'multisnapshot', 'nbody', 'fit'])
 
     # Build run config
     cfg = parse_nbody_config(cfg)

--- a/cmass/bias/rho_to_halo.py
+++ b/cmass/bias/rho_to_halo.py
@@ -181,7 +181,7 @@ def apply_charm(rho, fvel, charm_cfg, L, cosmo):
 
     # Pad the input density field
     rho_pad = np.pad(rho, pad, mode='wrap')
-    fvel_pad = np.pad(fvel, [(pad,pad)]*3+[(0,0)], mode='wrap')
+    fvel_pad = np.pad(fvel, [(pad, pad)]*3+[(0, 0)], mode='wrap')
 
     # Split the inputs into batches
     batch_rho = batch_cube(rho, Nsub, Npix, Npix)
@@ -195,9 +195,11 @@ def apply_charm(rho, fvel, charm_cfg, L, cosmo):
         logging.info(f'Processing CHARM batch {i+1}/{len(batch_rho)}...')
         hpos, hmass, hvel = charm_interface.process_input_density(
             rho_m_zg=batch_rho[i],
-            rho_m_vel_zg=np.stack([batch_fvel[i,...,j] for j in range(3)], axis=0),
+            rho_m_vel_zg=np.stack([batch_fvel[i, ..., j]
+                                  for j in range(3)], axis=0),
             rho_m_pad_zg=batch_rho_pad[i],
-            rho_m_vel_pad_zg=np.stack([batch_fvel_pad[i,...,j] for j in range(3)], axis=0),
+            rho_m_vel_pad_zg=np.stack(
+                [batch_fvel_pad[i, ..., j] for j in range(3)], axis=0),
             cosmology_array=np.array(cosmo),
             BoxSize=Lcharm
         )
@@ -276,7 +278,6 @@ def run_snapshot(rho, fvel, a, cfg, ppos=None, pvel=None):
         raise NotImplementedError(
             f'Model {cfg.bias.halo.model} not implemented.')
 
-
     logging.info('Combine...')
 
     def combine(x):
@@ -319,10 +320,11 @@ def save_snapshot(outdir, a, hpos, hvel, hmass):
 @hydra.main(version_base=None, config_path="../conf", config_name="config")
 def main(cfg: DictConfig) -> None:
     # Filtering for necessary configs
-    cfg = OmegaConf.masked_copy(cfg, ['meta', 'sim', 'nbody', 'bias'])
+    cfg = OmegaConf.masked_copy(
+        cfg, ['meta', 'sim', 'multisnapshot', 'nbody', 'bias'])
 
     # Build run config
-    cfg = parse_nbody_config(cfg, lightcone=True)
+    cfg = parse_nbody_config(cfg)
     logging.info('Running with config:\n' + OmegaConf.to_yaml(cfg))
     source_path = get_source_path(
         cfg.meta.wdir, cfg.nbody.suite, cfg.sim,

--- a/cmass/conf/config.yaml
+++ b/cmass/conf/config.yaml
@@ -12,5 +12,6 @@ defaults:
 # What base sim to use
 sim: pmwd
 
-# whether to use lightcone snapshot extrapolation (if available)
-lightcone: True
+# whether to run on multiple snapshots and use lightcone snapshot extrapolation
+# (if available)
+multisnapshot: True

--- a/cmass/conf/config.yaml
+++ b/cmass/conf/config.yaml
@@ -9,4 +9,8 @@ defaults:
   - diag: default
   - _self_
 
+# What base sim to use
 sim: pmwd
+
+# whether to use lightcone snapshot extrapolation (if available)
+lightcone: True

--- a/cmass/conf/survey/cmass_ngc.yaml
+++ b/cmass/conf/survey/cmass_ngc.yaml
@@ -7,9 +7,6 @@ u1: [1,1,0]
 u2: [0,0,1]
 u3: [1,0,0]
 
-# whether to use lightcone snapshot extrapolation (if available)
-lightcone: True
-
 # Fiber collision method
 fibermode: 1  # 0: no collisions, 1: one removed, 2: both removed
 

--- a/cmass/diagnostics/summ.py
+++ b/cmass/diagnostics/summ.py
@@ -110,7 +110,8 @@ def run_pylians(
 
     for summary_name in summaries:
         if summary_name == 'Pk':
-            k, Pk = calcPk(field, box_size, axis=axis, MAS='CIC', threads=num_threads)
+            k, Pk = calcPk(field, box_size, axis=axis,
+                           MAS='CIC', threads=num_threads)
             key = f"{'z' if use_rsd else ''}{summary_name}_k3D"
             group.create_dataset(key, data=k)
             key = f"{'z' if use_rsd else ''}{summary_name}"
@@ -124,10 +125,12 @@ def run_summarizer(
     pos, vel, h, redshift, box_size, grid_size,
     group, summaries, threads
 ):
-    # For two-point correlation, bispectrum, wavelets, density split, and k-nearest neighbors
-    
+    # For two-point correlation, bispectrum, wavelets, density split, and
+    # k-nearest neighbors
+
     # Get summaries in comoving space
-    box_catalogue = get_box_catalogue(pos=pos, z=redshift, L=box_size, N=grid_size)
+    box_catalogue = get_box_catalogue(
+        pos=pos, z=redshift, L=box_size, N=grid_size)
     for summ in summaries:
         store_summary(
             box_catalogue, group, summ,
@@ -224,10 +227,12 @@ def summarize_tracer(
                 mass = None
                 if density is not None:
                     if proxy not in f[a].keys():
-                        logging.error(f'{proxy} not found in {type} file at a={a}')
+                        logging.error(
+                            f'{proxy} not found in {type} file at a={a}')
                     if len(pos) <= Ncut:
                         logging.warning(f'Not enough {type} tracers in {a}')
-                    logging.info(f'Cutting top {Ncut} out of {len(pos)} {type} tracers to match number density')
+                    logging.info(
+                        f'Cutting top {Ncut} out of {len(pos)} {type} tracers to match number density')
                     mass = f[a][proxy][...].astype(np.float32)
                     mask = np.argsort(mass)[-Ncut:]  # Keep top Ncut tracers
                     pos = pos[mask]
@@ -253,7 +258,7 @@ def summarize_tracer(
                         field, group, ['Pk'],
                         L, axis=0, num_threads=threads, use_rsd=True
                     )
-                
+
                 # Compute other summaries
                 others = [s for s in summaries if s != 'Pk']
                 if len(others) > 0:
@@ -277,7 +282,7 @@ def summarize_tracer(
 def main(cfg: DictConfig) -> None:
     # Filtering for necessary configs
     cfg = OmegaConf.masked_copy(
-        cfg, ['meta', 'sim', 'nbody', 'bias', 'diag', 'survey'])
+        cfg, ['meta', 'sim', 'multisnapshot', 'nbody', 'bias', 'diag'])
     logging.info('Running with config:\n' + OmegaConf.to_yaml(cfg))
 
     cfg = parse_nbody_config(cfg)
@@ -304,7 +309,7 @@ def main(cfg: DictConfig) -> None:
     all_done &= done
 
     # measure halo diagnostics
-    N = (cfg.nbody.L//1000)*128  # Set fixed diagnostics resolution. 128 cells per 1000 Mpc/h
+    N = (cfg.nbody.L//1000)*128  # fixed resolution at 128 cells per 1000 Mpc/h
     done = summarize_tracer(
         source_path, cfg.nbody.L, N, h=cfg.nbody.cosmo[2],
         density=cfg.diag.halo_density,
@@ -315,7 +320,7 @@ def main(cfg: DictConfig) -> None:
     )
     all_done &= done
 
-    # measure gal diagnostics
+    # measure galaxy diagnostics
     done = summarize_tracer(
         source_path, cfg.nbody.L, N, cfg.nbody.cosmo[2],
         density=cfg.diag.galaxy_density,

--- a/cmass/diagnostics/summ_lc.py
+++ b/cmass/diagnostics/summ_lc.py
@@ -20,20 +20,20 @@ import astropy
 
 
 def lc_summ(source_path, hod_seed, aug_seed, L, N, cosmo, threads=16,
-             from_scratch=True, **header_kwargs):
+            from_scratch=True, **header_kwargs):
     # check if diagnostics already computed
-    outpath = join(source_path, 'diag', 'lightcone', f'hod{hod_seed:05}_aug{aug_seed:05}.h5')
+    outpath = join(source_path, 'diag', 'lightcone',
+                   f'hod{hod_seed:05}_aug{aug_seed:05}.h5')
     if (not from_scratch) and os.path.isfile(outpath):
         logging.info('Gal diagnostics already computed')
         return True
 
     # check for file keys
-    filename = join(source_path, 'lightcone', f'hod{hod_seed:05}_aug{aug_seed:05}.h5')
+    filename = join(source_path, 'lightcone',
+                    f'hod{hod_seed:05}_aug{aug_seed:05}.h5')
     if not os.path.isfile(filename):
         logging.error(f'gal file not found: {filename}')
         return False
-    with h5py.File(filename, 'r') as f:
-        alist = list(f.keys())
 
     logging.info(f'Saving lc diagnostics to {outpath}')
     os.makedirs(join(source_path, 'diag'), exist_ok=True)
@@ -42,7 +42,8 @@ def lc_summ(source_path, hod_seed, aug_seed, L, N, cosmo, threads=16,
     # compute diagnostics and save
     with h5py.File(filename, 'r') as f:
         with h5py.File(outpath, 'w') as o:
-            logging.info(f'Processing lightcone catalog hod{hod_seed:05}_aug{aug_seed:05}')
+            logging.info(
+                f'Processing lightcone catalog hod{hod_seed:05}_aug{aug_seed:05}')
             # Load
             ra = f['ra'][...]
             dec = f['dec'][...]
@@ -56,7 +57,7 @@ def lc_summ(source_path, hod_seed, aug_seed, L, N, cosmo, threads=16,
             xyz += [1800, 1650, 150]
 
             # # noise positions
-            xyz += np.random.randn(*xyz.shape) # * 20 # 8/np.sqrt(3)
+            xyz += np.random.randn(*xyz.shape)  # * 20 # 8/np.sqrt(3)
 
             # convert to float32
             xyz = xyz.astype(np.float32)
@@ -79,7 +80,8 @@ def lc_summ(source_path, hod_seed, aug_seed, L, N, cosmo, threads=16,
 @hydra.main(version_base=None, config_path="../conf", config_name="config")
 def main(cfg: DictConfig) -> None:
     # Filtering for necessary configs
-    cfg = OmegaConf.masked_copy(cfg, ['meta', 'sim', 'nbody', 'bias', 'diag', 'survey'])
+    cfg = OmegaConf.masked_copy(
+        cfg, ['meta', 'sim', 'multisnapshot', 'nbody', 'bias', 'diag'])
     logging.info('Running with config:\n' + OmegaConf.to_yaml(cfg))
 
     cfg = parse_nbody_config(cfg)
@@ -102,7 +104,7 @@ def main(cfg: DictConfig) -> None:
 
     # measure gal diagnostics
     done = lc_summ(
-        source_path, cfg.bias.hod.seed, cfg.survey.aug_seed, 
+        source_path, cfg.bias.hod.seed, cfg.survey.aug_seed,
         L, N, cosmo,
         threads=threads, from_scratch=from_scratch,
         cosmology=cfg.nbody.cosmo, **cfg.bias.hod.theta)

--- a/cmass/nbody/borglpt.py
+++ b/cmass/nbody/borglpt.py
@@ -106,7 +106,7 @@ def main(cfg: DictConfig) -> None:
     rank = comm.Get_rank()
 
     # Filtering for necessary configs
-    cfg = OmegaConf.masked_copy(cfg, ['meta', 'nbody'])
+    cfg = OmegaConf.masked_copy(cfg, ['meta', 'nbody', 'multisnapshot'])
 
     # Build run config
     cfg = parse_nbody_config(cfg)

--- a/cmass/nbody/borgpm.py
+++ b/cmass/nbody/borgpm.py
@@ -103,7 +103,7 @@ def main(cfg: DictConfig) -> None:
     rank = comm.Get_rank()
 
     # Filtering for necessary configs
-    cfg = OmegaConf.masked_copy(cfg, ['meta', 'nbody'])
+    cfg = OmegaConf.masked_copy(cfg, ['meta', 'nbody', 'multisnapshot'])
 
     # Build run config
     cfg = parse_nbody_config(cfg)

--- a/cmass/nbody/borgpm_lc.py
+++ b/cmass/nbody/borgpm_lc.py
@@ -100,10 +100,10 @@ def delete_outputs(outdir):
 @hydra.main(version_base=None, config_path="../conf", config_name="config")
 def main(cfg: DictConfig) -> None:
     # Filtering for necessary configs
-    cfg = OmegaConf.masked_copy(cfg, ['meta', 'nbody'])
+    cfg = OmegaConf.masked_copy(cfg, ['meta', 'nbody', 'multisnapshot'])
 
     # Build run config
-    cfg = parse_nbody_config(cfg, lightcone=True)
+    cfg = parse_nbody_config(cfg)
     logging.info(f"Working directory: {os.getcwd()}")
     logging.info(
         "Logging directory: " +

--- a/cmass/nbody/pmwd.py
+++ b/cmass/nbody/pmwd.py
@@ -97,7 +97,7 @@ def run_density(wn, pmconf, pmcosmo):
 @hydra.main(version_base=None, config_path="../conf", config_name="config")
 def main(cfg: DictConfig) -> None:
     # Filtering for necessary configs
-    cfg = OmegaConf.masked_copy(cfg, ['meta', 'nbody'])
+    cfg = OmegaConf.masked_copy(cfg, ['meta', 'nbody', 'multisnapshot'])
 
     # Build run config
     cfg = parse_nbody_config(cfg)

--- a/cmass/nbody/tools.py
+++ b/cmass/nbody/tools.py
@@ -48,9 +48,8 @@ def parse_nbody_config(cfg):
         nbody.matchIC = nbody.matchIC > 0  # whether to match ICs to file
 
         # default asave
-        if not cfg.multisnapshot:
-            if (('asave' not in nbody) or (len(nbody.asave) == 0)):
-                nbody.asave = [nbody.af]
+        if ((not cfg.multisnapshot) or ('asave' not in nbody) or (len(nbody.asave) == 0)):
+            nbody.asave = [nbody.af]
 
         # load cosmology
         nbody.cosmo = load_params(nbody.lhid, cfg.meta.cosmofile)

--- a/cmass/survey/ngc_lightcone.py
+++ b/cmass/survey/ngc_lightcone.py
@@ -82,7 +82,7 @@ def stitch_lightcone(lightcone, source_path, snap_times, hod_seed):
 def main(cfg: DictConfig) -> None:
     # Filtering for necessary configs
     cfg = OmegaConf.masked_copy(
-        cfg, ['meta', 'sim', 'nbody', 'bias', 'survey'])
+        cfg, ['meta', 'sim', 'multisnapshot', 'nbody', 'bias', 'survey'])
 
     # Build run config
     cfg = parse_nbody_config(cfg)

--- a/cmass/survey/ngc_selection.py
+++ b/cmass/survey/ngc_selection.py
@@ -160,7 +160,7 @@ def reweight(rdz, wdir='./data', be=None, hobs=None):
 def main(cfg: DictConfig) -> None:
     # Filtering for necessary configs
     cfg = OmegaConf.masked_copy(
-        cfg, ['meta', 'sim', 'nbody', 'bias', 'survey'])
+        cfg, ['meta', 'sim', 'multisnapshot', 'nbody', 'bias', 'survey'])
 
     # Build run config
     cfg = parse_nbody_config(cfg)

--- a/cmass/survey/ngc_selection.py
+++ b/cmass/survey/ngc_selection.py
@@ -163,6 +163,9 @@ def main(cfg: DictConfig) -> None:
         cfg, ['meta', 'sim', 'multisnapshot', 'nbody', 'bias', 'survey'])
 
     # Build run config
+    if cfg.multisnapshot:
+        raise ValueError('This script only works for single-snapshot mode.')
+
     cfg = parse_nbody_config(cfg)
     logging.info('Running with config:\n' + OmegaConf.to_yaml(cfg))
     source_path = get_source_path(

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -101,6 +101,12 @@ python -m cmass.bias.apply_hod nbody=1gpch
 
 # Construct the lightcone and apply the NGC survey mask
 python -m cmass.survey.ngc_selection nbody=1gpch
+
+# Measure summaries in the simulation box (halos, galaxies)
+python -m cmass.diagnostics.summ nbody=1gpch
+
+# Measure summaries in the survey space (galaxies on the lightcone)
+python -m cmass.summary.Pk nbody=1gpch
 ```
 
 After all the above steps are completed, you should see the data results in your working directory as follows:
@@ -114,11 +120,16 @@ After all the above steps are completed, you should see the data results in your
 |   |   |   |   |   +-- nbody.h5  # density and velocity fields
 |   |   |   |   |   +-- halos.h5      # halo positions, velocity and masses
 |   |   |   |   |   +-- galaxies
-|   |   |   |   |   |   +-- hod000.h5   # galaxy positions/velocities, for HOD seed 0
+|   |   |   |   |   |   +-- hod00000.h5   # galaxy positions/velocities, for HOD seed 0
 |   |   |   |   |   +-- lightcone           
-|   |   |   |   |   |   +-- hod000_aug000.h5  # ra (deg), dec (deg), redshift of galaxies after survey mask
-|   |   |   |   |   +-- summary
-|   |   |   |   |   |   +-- hod000_aug000.h5        # survey-space power spectrum
+|   |   |   |   |   |   +-- hod00000_aug00000.h5  # ra (deg), dec (deg), redshift of galaxies after survey mask
+|   |   |   |   |   +-- diag  # simulation box summaries
+|   |   |   |   |   |   +-- rho.h5
+|   |   |   |   |   |   +-- halos.h5
+|   |   |   |   |   |   +-- galaxies
+|   |   |   |   |   |   |   +-- hod00000.h5
+|   |   |   |   |   +-- summary  # survey-space summaries
+|   |   |   |   |   |   +-- hod00000_aug00000.h5        # survey-space power spectrum
 ```
 
 
@@ -136,8 +147,11 @@ We can then define different suites of simulations based on large-scale configur
 ```bash
 python -m cmass.nbody.pmwd nbody=2gpch
 ```
-You can see other default configurations in [`cmass/conf`](../cmass/conf).
-
+You can see various default configurations in [`cmass/conf`](../cmass/conf). However, the two most commonly used are `sim` and `multisnapshot` as described in [`cmass/conf/config.yaml`](../cmass/conf/config.yaml). For example:
+```bash
+python -m cmass.bias.rho_to_halo nbody=1gpch sim=fastpm multisnapshot=True
+```
+`sim` tells the script which base nbody simulator (pmwd, fastpm, borglpt, borgpm, pinocchio) the script should use data products from. `multisnapshot` is a boolean flag that tells the script whether to use all simulation snapshots available, or only the final snapshot. The defaults are `sim=pmwd` and `multisnapshot=True`.
 
 ## Additional Functionality
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,3 +34,9 @@ syren =
     symbolic_pofk @ git+https://github.com/DeaglanBartlett/symbolic_pofk.git
 charm = 
     charm @ git+https://github.com/shivampcosmo/CHARM.git
+
+[flake8]
+max-line-length = 80
+
+[pep8]
+max-line-length = 80


### PR DESCRIPTION
`cmass.nbody.tools.parse_nbody_config` needs to know whether we want to run single-snapshot scripts, or generate halos, galaxies, and lightcone extrapolants on every available simulation snapshot. This has been added to the configuration as `cfg.multisnapshot` with a default as true

We also:
* Update the documentation to include descriptions of `sim` and `multisnapshot` flags
* Update INSTALL.md to have the correct simulation hierarchy
* Run autopep8 on all changed files