### PR TITLE
Turn off open_triangles in Bk calculations to enforce k1<k2+k3

### DIFF
--- a/cmass/diagnostics/tools.py
+++ b/cmass/diagnostics/tools.py
@@ -205,10 +205,14 @@ def calcBk_bfast(delta, L, axis=0, MAS='CIC', threads=16, cache_dir=None):
         file_path=cache_dir, open_triangles=False
     )
 
-    k123 = result[:, :3].T * kF
-    pk = result[:, 3:6].T
-    bk = result[:, 6:7].T
-    counts = result[7]  # number of triangles in each bin (not used)
+    # remove when k0 >= k1 + k2, because open_triangles=False doesn't do it
+    k123 = result[:, :3].T * kF  # k123
+    mask = k123[0] < k123[1] + k123[2]
+
+    k123 = k123[:, mask]
+    pk = result[mask, 3:6].T
+    bk = result[mask, 6:7].T
+    counts = result[mask, 7]  # number of triangles in each bin (not used)
     qk = calcQk_bfast(pk, bk)
 
     return k123, bk, qk, k123, pk

--- a/cmass/diagnostics/tools.py
+++ b/cmass/diagnostics/tools.py
@@ -200,9 +200,9 @@ def calcBk_bfast(delta, L, axis=0, MAS='CIC', threads=16, cache_dir=None):
     fc = dk = kmax/kF/(Nbins+1/2)  # span kF to kmax
 
     result = BFast.Bk(
-        delta, L, fc, dk, Nbins, 'All', MAS=MAS,
+        delta, L, fc, dk, Nbins, triangle_type='All', MAS=MAS,
         fast=True, precision='float32', verbose=False,
-        file_path=cache_dir
+        file_path=cache_dir, open_triangles=False
     )
 
     k123 = result[:, :3].T * kF

--- a/cmass/diagnostics/tools.py
+++ b/cmass/diagnostics/tools.py
@@ -205,7 +205,7 @@ def calcBk_bfast(delta, L, axis=0, MAS='CIC', threads=16, cache_dir=None):
         file_path=cache_dir, open_triangles=False
     )
 
-    # remove when k0 >= k1 + k2, because open_triangles=False doesn't do it
+    # remove when k1 >= k2 + k3, because open_triangles=False doesn't do it
     k123 = result[:, :3].T * kF  # k123
     mask = k123[0] < k123[1] + k123[2]
 

--- a/cmass/infer/loaders.py
+++ b/cmass/infer/loaders.py
@@ -132,8 +132,16 @@ def preprocess_Bk(X, kmax, log=False):
     Xout = []
     for x in X:
         k, value = x['k'], x['value']
-        # cut k
-        value = value[~ np.any(k > kmax, axis=0)]
+        # cut kmax
+        m = ~ np.any(k > kmax, axis=0)
+        value = value[m]
+        k = k[:, m]
+        
+        # check if k1+k2 < k3
+        k1, k2, k3 = k
+        m = (k1 + k2 > k3)
+        value = value[m]
+
         if log:
             value = np.log10(value)
         Xout.append(value)

--- a/cmass/infer/loaders.py
+++ b/cmass/infer/loaders.py
@@ -136,10 +136,10 @@ def preprocess_Bk(X, kmax, log=False):
         m = ~ np.any(k > kmax, axis=0)
         value = value[m]
         k = k[:, m]
-        
-        # check if k1+k2 < k3
+
+        # check if k1 >= k2 + k3
         k1, k2, k3 = k
-        m = (k1 + k2 > k3)
+        m = (k1 < k2 + k3)
         value = value[m]
 
         if log:


### PR DESCRIPTION
In the old Bfast implementation, we had the default open_triangles=True which caused some modes to be measured where k1 >= k2+k3. In these does, the power was effectively 0, which made our summaries very  noisy and unsmooth.

This PR:

- adds `open_triangles=False` to the Bfast computation
- adds another masking after Bfast computation to ensure all 
- checks and removes modes where k1 >= k2+k3 in `cmass.infer.loaders.preprocess_Bk` to allow for backwards compatibility

Here's before/after:
![image](https://github.com/user-attachments/assets/06a77cdd-ac1f-44b7-aff2-39c0639a0bdf)

Problem raised by @suicee 