### PR TITLE
Adds the option to remove shot noise when preprocessing summaries in cmass.infer

### DIFF
--- a/cmass/conf/infer/default.yaml
+++ b/cmass/conf/infer/default.yaml
@@ -9,6 +9,8 @@ device: cpu  # cpu or cuda
 # ~~ EXPERIMENT ARGS ~~
 Nmax: -1  # maximum number of simulations to load (-1 for all)
 
+correct_shot: true  # whether to correct for shot noise when normalizing
+
 halo: True      # whether to train on halo summaries
 galaxy: False    # whether to train on galaxy summaries
 ngc_lightcone: False # whether to train on ngc_lightcone summaries

--- a/cmass/conf/infer/simple.yaml
+++ b/cmass/conf/infer/simple.yaml
@@ -9,6 +9,8 @@ device: cpu  # cpu or cuda
 # ~~ EXPERIMENT ARGS ~~
 Nmax: -1  # maximum number of simulations to load (-1 for all)
 
+correct_shot: true  # whether to correct for shot noise when normalizing
+
 halo: True      # whether to train on halo summaries
 galaxy: False    # whether to train on galaxy summaries
 ngc_lightcone: False # whether to train on ngc_lightcone summaries

--- a/cmass/diagnostics/summ.py
+++ b/cmass/diagnostics/summ.py
@@ -222,6 +222,8 @@ def summarize_tracer(
 
         # Save number density of tracers
         out_attrs['nbar'] = len(pos) / L**3  # Number density (h/Mpc)^3
+        out_attrs['log10nbar'] = \
+            np.log10(len(pos)) - 3 * np.log10(L)  # for numerical precision
         out_attrs['high_res'] = high_res
 
         # Noise out positions (we do not probe less than Lnoise)
@@ -364,6 +366,8 @@ def summarize_lightcone(
     out_attrs = {}
     # Save number density of tracers
     out_attrs['nbar'] = len(pos) / L**3  # Number density (h/Mpc)^3
+    out_attrs['log10nbar'] = \
+        np.log10(len(pos)) - 3 * np.log10(L)  # for numerical precision
     out_attrs['high_res'] = high_res
 
     out_data = {}

--- a/cmass/diagnostics/summ.py
+++ b/cmass/diagnostics/summ.py
@@ -220,9 +220,9 @@ def summarize_tracer(
             vel = vel[mask]
             mass = mass[mask]
 
-            out_attrs['density'] = float(density)
-        else:
-            out_attrs['density'] = np.nan
+        # Save number density of tracers
+        out_attrs['nbar'] = len(pos) / L**3  # Number density (h/Mpc)^3
+        out_attrs['high_res'] = high_res
 
         # Noise out positions (we do not probe less than Lnoise)
         Lnoise = (1000/128)/np.sqrt(3)  # Set by CHARM resolution
@@ -361,6 +361,11 @@ def summarize_lightcone(
         logging.error('Error! Some tracers outside of box!')
         return False
 
+    out_attrs = {}
+    # Save number density of tracers
+    out_attrs['nbar'] = len(pos) / L**3  # Number density (h/Mpc)^3
+    out_attrs['high_res'] = high_res
+
     out_data = {}
     # Compute P(k)
     if 'Pk' in summaries:
@@ -400,7 +405,7 @@ def summarize_lightcone(
         )
         out_data.update(out)
 
-    save_group(outpath, out_data, None, None,
+    save_group(outpath, out_data, out_attrs, None,
                config, save_HOD=True)
     return True
 

--- a/cmass/infer/loaders.py
+++ b/cmass/infer/loaders.py
@@ -4,7 +4,7 @@ from os.path import join
 import h5py
 import numpy as np
 from omegaconf import OmegaConf
-from cmass.bias.hod import lookup_hod_model
+from cmass.bias.tools.hod import lookup_hod_model
 
 
 def get_cosmo(source_path):

--- a/cmass/infer/loaders.py
+++ b/cmass/infer/loaders.py
@@ -214,7 +214,7 @@ def _load_single_simulation_summaries(sourcepath, tracer, a=None, only_cosmo=Fal
     # specify paths to diagnostics
     diagpath = join(sourcepath, 'diag')
     if tracer == 'galaxy':
-        diagpath = join(diagpath, 'galaxies')  # oops
+        diagpath = join(diagpath, 'galaxies')
     elif 'lightcone' in tracer:
         diagpath = join(diagpath, f'{tracer}')
     if not os.path.isdir(diagpath):

--- a/cmass/infer/loaders.py
+++ b/cmass/infer/loaders.py
@@ -120,19 +120,26 @@ def _filter_Pk(X, kmin, kmax):
         [x['value'][_is_in_kminmax(x['k'], kmin, kmax)] for x in X])
 
 
-def _get_nbar(X):
-    return np.array([x['log10nbar'] for x in X]).reshape(-1, 1)
+def _get_nbar(data):
+    return np.array([x['log10nbar'] for x in data]).reshape(-1, 1)
+
+
+def signed_log(x, base=10):
+    # Compute the signed logarithm of x (for negative values)
+    return np.sign(x) * np.log1p(np.abs(x)) / np.log(base)
 
 
 def preprocess_Pk(data, kmax, monopole=True, norm=None, kmin=0., correct_shot=False):
-   # process Pk: filtering for k's, normalizing, and flattening
+    # process Pk: filtering for k's, normalizing, and flattening
     if not monopole and norm is None:
         raise ValueError('norm must be provided when monopole is False')
 
     X = _filter_Pk(data, kmin, kmax)
 
     if monopole:
-        X = np.log(X)
+        X = signed_log(X)
+        if correct_shot:
+            X /= np.sqrt(2 * np.pi)
     else:
         Xnorm = _filter_Pk(norm, kmin, kmax)
         X /= Xnorm
@@ -168,7 +175,7 @@ def preprocess_Bk(data, kmax, kmin=0., log=False, equilateral_only=False, correc
     X = _filter_Bk(data, kmin, kmax, equilateral_only)
 
     if log:
-        X = np.log10(X)
+        X = signed_log(X)
 
     return np.nan_to_num(X, nan=0.0).reshape(len(X), -1)
 

--- a/cmass/infer/preprocess.py
+++ b/cmass/infer/preprocess.py
@@ -124,7 +124,8 @@ def run_preprocessing(summaries, parameters, ids, hodprior, exp, cfg, model_path
                     eq_bool = False
                 x, theta, id = summaries[summ], parameters[summ], ids[summ]
                 if 'Pk0' in summ:
-                    x = preprocess_Pk(x, kmax, monopole=True, kmin=kmin)
+                    x = preprocess_Pk(x, kmax, monopole=True, kmin=kmin,
+                                      correct_shot=cfg.infer.correct_shot)
                 elif 'Pk' in summ:
                     norm_key = summ[:-1] + '0'  # monopole (Pk0 or zPk0)
                     if norm_key in summaries:
@@ -136,10 +137,12 @@ def run_preprocessing(summaries, parameters, ids, hodprior, exp, cfg, model_path
                             f'Need monopole for normalization of {summ}')
                 elif 'Bk' in summ:
                     x = preprocess_Bk(x, kmax, log=True,
-                                      equilateral_only=eq_bool, kmin=kmin)
+                                      equilateral_only=eq_bool, kmin=kmin,
+                                      correct_shot=cfg.infer.correct_shot)
                 elif 'Qk' in summ:
                     x = preprocess_Bk(x, kmax, log=False,
-                                      equilateral_only=eq_bool, kmin=kmin)
+                                      equilateral_only=eq_bool, kmin=kmin,
+                                      correct_shot=cfg.infer.correct_shot)
                 else:
                     raise NotImplementedError  # TODO: implement other summaries
                 xs.append(x)

--- a/cmass/utils/utils.py
+++ b/cmass/utils/utils.py
@@ -46,8 +46,10 @@ def save_cfg(source_path, cfg, field=None):
         if field is not None:
             cfg = OmegaConf.masked_copy(cfg, field)
             cfg = OmegaConf.merge(old_cfg, cfg)
-    os.remove(join(source_path, 'config.yaml'))
-    OmegaConf.save(cfg, join(source_path, 'config.yaml'))
+    filename = join(source_path, 'config.yaml')
+    if os.path.isfile(filename):
+        os.remove(filename)
+    OmegaConf.save(cfg, filename)
 
 
 def load_params(index, cosmofile):

--- a/jobs/slurm_inference.sh
+++ b/jobs/slurm_inference.sh
@@ -12,28 +12,28 @@
 
 
 SLURM_ARRAY_TASK_ID=0
-export TQDM_DISABLE=0
+# export TQDM_DISABLE=0
 
 module restore cmass
 conda activate cmass
 
-exp_index=9
+exp_index=null
 net_index=$SLURM_ARRAY_TASK_ID
 
 # Command to run for each lhid
 cd /home/x-mho1/git/ltu-cmass
 
-nbody=mtnglike
-sim=fastpm
-infer=default
+nbody=quijote
+sim=nbody_leauthaud
+infer=simple
 
 halo=False
-galaxy=False
-ngc=True
+galaxy=True
+ngc=False
 sgc=False
 mtng=False
 
-extras="nbody.zf=0.500015"
+extras="nbody.zf=0.5"
 device=cuda
 
 suffix="nbody=$nbody sim=$sim infer=$infer infer.exp_index=$exp_index infer.net_index=$net_index"
@@ -42,6 +42,6 @@ suffix="$suffix infer.ngc_lightcone=$ngc infer.sgc_lightcone=$sgc infer.mtng_lig
 suffix="$suffix infer.device=$device $extras"
 
 echo "Running inference with $suffix"
-# python -m cmass.infer.preprocess $suffix
-python -m cmass.infer.train $suffix net=tuning
+python -m cmass.infer.preprocess $suffix
+# python -m cmass.infer.train $suffix net=tuning
 # python -m cmass.infer.validate $suffix

--- a/notebooks/compute_nbar.ipynb
+++ b/notebooks/compute_nbar.ipynb
@@ -1,0 +1,154 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8d075cae",
+   "metadata": {},
+   "source": [
+    "## Save nbar\n",
+    "Due to a recent PR, we now save the number density of every summary in the group attributes. This notebook goes back and saves `nbar` for all older diagnostics files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "302bc273",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
+    "%matplotlib inline\n",
+    "\n",
+    "import os\n",
+    "from os.path import join\n",
+    "import pickle\n",
+    "import json\n",
+    "import h5py\n",
+    "import matplotlib as mpl\n",
+    "import matplotlib.pyplot as plt\n",
+    "# mpl.style.use('../../style.mcstyle')   # noqa\n",
+    "import numpy as np\n",
+    "import torch\n",
+    "import seaborn as sns\n",
+    "import pandas as pd\n",
+    "import warnings\n",
+    "from tqdm import tqdm\n",
+    "\n",
+    "# Suppress warnings\n",
+    "warnings.filterwarnings('ignore')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "ab33c3cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wdir = '/anvil/scratch/x-mho1/cmass-ili'\n",
+    "nbody = 'quijote'\n",
+    "sim = 'nbody_leauthaud'\n",
+    "L, N = 1000, 128\n",
+    "\n",
+    "suitepath = join(wdir, nbody, sim, f'L{L}-N{N}')\n",
+    "\n",
+    "tracer = 'galaxies'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ab1a18ea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def compute_nbar(Ngals, L):\n",
+    "    return Ngals / L**3\n",
+    "\n",
+    "\n",
+    "def compute_log10nbar(Ngals, L):\n",
+    "    return np.log10(Ngals) - 3 * np.log10(L)\n",
+    "\n",
+    "\n",
+    "def process_file(ingroup, outgroup, Nmin, L):\n",
+    "    key = 'pos' if 'pos' in ingroup.keys() else 'ra'\n",
+    "    Ngals = min(len(ingroup[key]), Nmin)\n",
+    "    nbar = compute_nbar(Ngals, L)\n",
+    "    log10nbar = compute_log10nbar(Ngals, L)\n",
+    "    print(nbar, log10nbar)\n",
+    "    # outgroup.attrs['nbar'] = nbar\n",
+    "    # outgroup.attrs['log10nbar'] = log10nbar\n",
+    "\n",
+    "\n",
+    "def process_halogalaxy_diag(tracerfile, diagfile, Nmin, L):\n",
+    "    with h5py.File(tracerfile, 'r') as g, h5py.File(diagfile, 'a') as f:\n",
+    "        for key in f.keys():\n",
+    "            process_file(g[key], f[key], Nmin, L)\n",
+    "\n",
+    "\n",
+    "def process_lightcone_diag(tracerfile, diagfile, Nmin, L):\n",
+    "    with h5py.File(tracerfile, 'r') as g, h5py.File(diagfile, 'a') as f:\n",
+    "        process_file(g, f, Nmin, L)\n",
+    "\n",
+    "\n",
+    "def process_lhid(lhid, suitepath, tracer, Nmin, L):\n",
+    "    tracerpath = join(suitepath, lhid, tracer)\n",
+    "    diagpath = join(suitepath, lhid, 'diag', tracer)\n",
+    "    if tracer == 'halos':\n",
+    "        tracerpath += '.h5'\n",
+    "        diagpath += '.h5'\n",
+    "        if not os.path.exists(diagpath):\n",
+    "            return\n",
+    "        process_halogalaxy_diag(tracerpath, diagpath, Nmin, L)\n",
+    "    else:  # galaxies and lightcone\n",
+    "        if not os.path.exists(diagpath):\n",
+    "            return\n",
+    "        for f in os.listdir(diagpath):\n",
+    "            diagfile = join(diagpath, f)\n",
+    "            tracerfile = join(tracerpath, f)\n",
+    "            if tracer == 'galaxies':\n",
+    "                process_halogalaxy_diag(tracerfile, diagfile, Nmin, L)\n",
+    "            elif 'lightcone' in tracer:\n",
+    "                process_lightcone_diag(tracerfile, diagfile, Nmin, L)\n",
+    "\n",
+    "\n",
+    "nbar_min = np.inf\n",
+    "Nmin = nbar_min * L**3\n",
+    "\n",
+    "for lhid in tqdm(os.listdir(suitepath)):\n",
+    "    process_lhid(lhid, suitepath, tracer, Nmin, L)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4acb047e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Changes:

- Only removes shot noise from the Pk monopole. Higher order Pk poles and Bk were not so straightforward
- diagnostics now save `nbar` and `log10nbar` as attributes
- Refactoring some preprocessing functions to make  the code easier to read
- Adds `compute_nbar.ipynb` notebook to save `nbar` to diagnostics after the fact
- Fixes an overwriting bug in `save_cfg`