### PR TITLE
Adds ability to specify a custom HOD prior

### DIFF
--- a/cmass/bias/apply_hod.py
+++ b/cmass/bias/apply_hod.py
@@ -43,6 +43,7 @@ def populate_hod(
     zpivot=None,
     assem_bias=False,
     vel_assem_bias=False,
+    custom_prior=None,
 ):
     cosmo = cosmo_to_astropy(cosmo)
 
@@ -73,6 +74,7 @@ def populate_hod(
         zpivot=zpivot,
         assem_bias=assem_bias,
         vel_assem_bias=vel_assem_bias,
+        custom_prior=custom_prior,
     )
     hod.populate_mock(catalog, seed=seed, halo_mass_column_key=f'halo_m{mdef}')
     galcat = hod.mock.galaxy_table.as_array()
@@ -93,6 +95,7 @@ def run_snapshot(hpos, hvel, hmass, a, cfg, hmeta=None):
         zpivot=getattr(cfg.bias.hod, "zpivot", None),
         assem_bias=getattr(cfg.bias.hod, "assem_bias", False),
         vel_assem_bias=getattr(cfg.bias.hod, "vel_assem_bias", False),
+        custom_prior=getattr(cfg.bias.hod, "custom_prior", None),
     )
 
     # Organize outputs

--- a/cmass/bias/tools/hod.py
+++ b/cmass/bias/tools/hod.py
@@ -47,7 +47,7 @@ def lookup_hod_model(model=None, assem_bias=False, vel_assem_bias=False, zpivot=
 def parse_hod(cfg):
     """
     Parse HOD parameters in the config file, and set them
-    in the `cfg` object
+    in the `cfg` object. TODO: IS THIS STILL NEEDED?
 
     Args:
         cfg (object)

--- a/cmass/bias/tools/hod.py
+++ b/cmass/bias/tools/hod.py
@@ -23,7 +23,7 @@ from .hod_models import (
 )
 
 
-def lookup_hod_model(model=None, assem_bias=False, vel_assem_bias=False, zpivot=None):
+def lookup_hod_model(model=None, assem_bias=False, vel_assem_bias=False, zpivot=None, custom_prior=None):
     if model is None:
         return Zheng07()  # for backwards compatibility
     elif model == "zheng07":
@@ -34,7 +34,8 @@ def lookup_hod_model(model=None, assem_bias=False, vel_assem_bias=False, zpivot=
                            vel_assem_bias=vel_assem_bias)
     elif model == 'zheng07zinterp':
         return Zheng07zinterp(zpivot, assem_bias=assem_bias,
-                              vel_assem_bias=vel_assem_bias)
+                              vel_assem_bias=vel_assem_bias,
+                              custom_prior=custom_prior)
     elif model == 'leauthaud11':
         return Leauthaud11()
     elif model == "zu_mandelbaum15":
@@ -88,7 +89,9 @@ def parse_hod(cfg):
             assem_bias=cfg.bias.hod.assem_bias,
             vel_assem_bias=cfg.bias.hod.vel_assem_bias,
             zpivot=cfg.bias.hod.zpivot if hasattr(
-                cfg.bias.hod, "zpivot") else None
+                cfg.bias.hod, "zpivot") else None,
+            custom_prior=cfg.bias.hod.custom_prior if hasattr(
+                cfg.bias.hod, "custom_prior") else None,
         )
 
         # Check if we're using default parameters

--- a/cmass/bias/tools/hod.py
+++ b/cmass/bias/tools/hod.py
@@ -140,6 +140,7 @@ def build_HOD_model(
     zpivot=None,
     assem_bias=False,
     vel_assem_bias=False,
+    custom_prior=None,
 ):
     """Build a HOD model from the given HOD parameters.
 
@@ -178,7 +179,9 @@ def build_HOD_model(
                             vel_assem_bias=vel_assem_bias)
     elif model == 'zheng07zinterp':
         model = Zheng07zinterp(mass_def=mdef, zpivot=zpivot,
-                               assem_bias=assem_bias, vel_assem_bias=vel_assem_bias)
+                               assem_bias=assem_bias,
+                               vel_assem_bias=vel_assem_bias,
+                               custom_prior=custom_prior)
     elif model == "zu_mandelbaum15":
         model = Zu_mandelbaum15(mass_def=mdef)
     else:

--- a/cmass/bias/tools/hod_models.py
+++ b/cmass/bias/tools/hod_models.py
@@ -781,8 +781,8 @@ class Zheng07zinterp(Hod_model):
             pars = ["logMmin_z" + str(i) for i in range(npivot)]
             low = [None] * npivot
             up = [None] * npivot
-            loc = [12.8, 13.0, 13.2]
-            sig = [0.2, 0.15, 0.1]
+            loc = [12.83843, 13.05714, 13.25134]
+            sig = [0.24210, 0.19465, 0.13425]
             dist = ["norm"] * npivot
         else:
             raise NotImplementedError(

--- a/cmass/bias/tools/hod_models.py
+++ b/cmass/bias/tools/hod_models.py
@@ -50,12 +50,13 @@ class Hod_parameter:
     """
 
     def __init__(
-        self, key, value=None, upper=None, lower=None, sigma=None, distribution=None
+        self, key, value=None, upper=None, lower=None, loc=None, sigma=None, distribution=None
     ):
         self.key = key
         self.value = value
         self.upper = upper
         self.lower = lower
+        self.loc = loc
         self.sigma = sigma
         setattr(
             self, "distribution", "uniform" if distribution is None else distribution
@@ -75,6 +76,7 @@ class Hod_model:
         lower_bound,
         upper_bound,
         distribution=None,
+        loc=None,
         sigma=None,
         mass_def="vir",
         assem_bias=False,
@@ -84,6 +86,7 @@ class Hod_model:
         self.lower_bound = lower_bound
         self.upper_bound = upper_bound
         self.distribution = distribution
+        self.loc = loc
         self.sigma = sigma
 
         # Loop through parameters and initialise
@@ -92,11 +95,12 @@ class Hod_model:
             lower_bound,
             upper_bound,
             distribution or [],
+            loc or [],
             sigma or [],
             fillvalue=None,
         )
 
-        for _param, _lower, _upper, _dist, _sigma in zipped:
+        for _param, _lower, _upper, _dist, _loc, _sigma in zipped:
             setattr(
                 self,
                 _param,
@@ -104,6 +108,7 @@ class Hod_model:
                     key=_param,
                     lower=_lower,
                     upper=_upper,
+                    loc=_loc,
                     sigma=_sigma,
                     distribution=_dist,
                 ),
@@ -142,13 +147,15 @@ class Hod_model:
                 _upper = getattr(self, _param).upper
                 sampled_param = np.random.uniform(_lower, _upper)
             elif _dist == "norm":
-                sampled_param = np.random.normal(0, getattr(self, _param).sigma)
+                sampled_param = np.random.normal(
+                    getattr(self, _param).loc, getattr(self, _param).sigma)
             elif _dist == "truncnorm":
                 _lower = getattr(self, _param).lower
                 _upper = getattr(self, _param).upper
+                _loc = getattr(self, _param).loc
                 _sigma = getattr(self, _param).sigma
                 sampled_param = float(
-                    truncated_gaussian(0, _sigma, _lower, _upper)[0])
+                    truncated_gaussian(_loc, _sigma, _lower, _upper)[0])
             else:
                 raise NotImplementedError
             getattr(self, _param).value = sampled_param
@@ -229,6 +236,7 @@ class Zheng07(Hod_model):
         ],
         lower_bound=[12.0, 0.1, 13.0, 13.0, 0.0, 0.0, 0.2, 0.2, -1, -1],
         upper_bound=[14.0, 0.6, 15.0, 15.0, 1.5, 0.7, 2.0, 2.0, 1, 1],
+        location=[None, None, None, None, None, None, None, None, 0, 0],
         sigma=[None, None, None, None, None, None, None, None, 0.2, 0.2],
         distribution=[
             "uniform",
@@ -259,6 +267,7 @@ class Zheng07(Hod_model):
                      "conc_gal_bias_satellites"]
         low = [lower_bound[parameters.index(p)] for p in pars]
         up = [upper_bound[parameters.index(p)] for p in pars]
+        loc = [location[parameters.index(p)] for p in pars]
         sig = [sigma[parameters.index(p)] for p in pars]
         dist = [distribution[parameters.index(p)] for p in pars]
 
@@ -266,6 +275,7 @@ class Zheng07(Hod_model):
             parameters=pars,
             lower_bound=low,
             upper_bound=up,
+            loc=loc,
             sigma=sig,
             distribution=dist,
             mass_def=mass_def,
@@ -435,6 +445,8 @@ class Zheng07zdep(Hod_model):
             [12.0, 0.1, 13.0, 13.0, 0.0, -30.0, -10.0, 0.0, 0.2, 0.2, -1, -1]),
         upper_bound=np.array(
             [14.0, 0.6, 15.0, 15.0, 1.5, 0.0, 0.0, 0.7, 2.0, 2.0, 1, 1]),
+        location=[None, None, None, None, None, None,
+                  None, None, None, None, None, 0, 0],
         sigma=[None, None, None, None, None, None,
                None, None, None, None, 0.2, 0.2],
         distribution=[
@@ -470,6 +482,7 @@ class Zheng07zdep(Hod_model):
                      "conc_gal_bias_satellites"]
         low = [lower_bound[parameters.index(p)] for p in pars]
         up = [upper_bound[parameters.index(p)] for p in pars]
+        loc = [location[parameters.index(p)] for p in pars]
         sig = [sigma[parameters.index(p)] for p in pars]
         dist = [distribution[parameters.index(p)] for p in pars]
 
@@ -477,6 +490,7 @@ class Zheng07zdep(Hod_model):
             parameters=pars,
             lower_bound=low,
             upper_bound=up,
+            loc=loc,
             sigma=sig,
             distribution=dist,
             mass_def=mass_def,
@@ -646,6 +660,7 @@ class Zheng07zinterp(Hod_model):
         ],
         lower_bound=[12.0, 0.1, 13.0, 13.0, 0.0, 0.0, 0.2, 0.2, -1, -1],
         upper_bound=[14.0, 0.6, 15.0, 15.0, 1.5, 0.7, 2.0, 2.0, 1, 1],
+        location=[None, None, None, None, None, None, None, None, 0, 0],
         sigma=[None, None, None, None, None, None, None, None, 0.2, 0.2],
         distribution=[
             "uniform",
@@ -663,12 +678,14 @@ class Zheng07zinterp(Hod_model):
         mass_def="vir",
         assem_bias=False,
         vel_assem_bias=False,
+        custom_prior=None,
     ):
 
         # Obtain single mass parameter for each pivot point
         pars = []
         low = []
         up = []
+        loc = []
         sig = []
         dist = []
         self.zpivot = zpivot
@@ -681,11 +698,23 @@ class Zheng07zinterp(Hod_model):
         init_pars = ["logMmin", "sigma_logM", "logM0", "logM1", "alpha"]
         for p, v0, v1 in zip(init_pars, lower_bound, upper_bound):
             i = parameters.index(p)
-            if p in ["logMmin", "logM0", "logM1"]:
+            if p == "logMmin" and (custom_prior is not None):
+                _p = self._build_custom_prior(custom_prior, self.npivot)
+                pars += _p[0]
+                low += _p[1]
+                up += _p[2]
+                loc += _p[3]
+                sig += _p[4]
+                dist += _p[5]
+                if param_defaults is not None:
+                    defaults += [param_defaults[i]] * self.npivot
+
+            elif p in ["logMmin", "logM0", "logM1"]:
                 for j in range(self.npivot):
                     pars.append(p + "_z" + str(j))
                     low.append(v0)
                     up.append(v1)
+                    loc.append(location[i])
                     sig.append(sigma[i])
                     dist.append(distribution[i])
                     if param_defaults is not None:
@@ -694,6 +723,7 @@ class Zheng07zinterp(Hod_model):
                 pars.append(p)
                 low.append(v0)
                 up.append(v1)
+                loc.append(location[i])
                 sig.append(sigma[i])
                 dist.append(distribution[i])
                 if param_defaults is not None:
@@ -705,6 +735,7 @@ class Zheng07zinterp(Hod_model):
                 pars.append(p)
                 low.append(lower_bound[parameters.index(p)])
                 up.append(upper_bound[parameters.index(p)])
+                loc.append(location[parameters.index(p)])
                 sig.append(sigma[parameters.index(p)])
                 dist.append(distribution[parameters.index(p)])
         if vel_assem_bias:
@@ -712,6 +743,7 @@ class Zheng07zinterp(Hod_model):
                 pars.append(p)
                 low.append(lower_bound[parameters.index(p)])
                 up.append(upper_bound[parameters.index(p)])
+                loc.append(location[parameters.index(p)])
                 sig.append(sigma[parameters.index(p)])
                 dist.append(distribution[parameters.index(p)])
 
@@ -719,6 +751,7 @@ class Zheng07zinterp(Hod_model):
             parameters=pars,
             lower_bound=low,
             upper_bound=up,
+            loc=loc,
             sigma=sig,
             distribution=dist,
             mass_def=mass_def,
@@ -739,6 +772,22 @@ class Zheng07zinterp(Hod_model):
                 self.reid2014_cmass()
             else:
                 raise NotImplementedError
+
+    @staticmethod
+    def _build_custom_prior(custom_prior, npivot):
+        if custom_prior == 'mtng':
+            # MTNG prior
+            assert npivot == 3, "MTNG prior was only constrained for 3 pivot points"
+            pars = ["logMmin_z" + str(i) for i in range(npivot)]
+            low = [None] * npivot
+            up = [None] * npivot
+            loc = [12.8, 13.0, 13.2]
+            sig = [0.2, 0.15, 0.1]
+            dist = ["norm"] * npivot
+        else:
+            raise NotImplementedError(
+                f"Custom prior not implemented for {custom_prior}")
+        return pars, low, up, loc, sig, dist
 
     def set_occupation(self, **kwargs):
         if self.assem_bias:

--- a/cmass/conf/bias/zdep.yaml
+++ b/cmass/conf/bias/zdep.yaml
@@ -28,6 +28,9 @@ hod:
   assem_bias: True
   vel_assem_bias: True
 
+  # Whether to use a custom HOD prior, given an observed n(z)
+  custom_prior: mtng
+
   # Configure halo mass definition as stored in halo catalogs (e.g. vir, 200c)
   mdef: '200c'
 

--- a/cmass/diagnostics/summ.py
+++ b/cmass/diagnostics/summ.py
@@ -427,7 +427,7 @@ def summarize_lightcone(
         out_data.update(out)
 
     # Save n(z)
-    zbins = np.linspace(0.4, 0.7, 100)
+    zbins = np.linspace(0.4, 0.7, 101)  # spacing in dz = 0.003
     out_data['nz'], out_data['nz_bins'] = np.histogram(rdz[:, -1], bins=zbins)
 
     save_group(outpath, out_data, out_attrs, None,

--- a/cmass/diagnostics/summ.py
+++ b/cmass/diagnostics/summ.py
@@ -426,6 +426,10 @@ def summarize_lightcone(
         )
         out_data.update(out)
 
+    # Save n(z)
+    zbins = np.linspace(0.4, 0.7, 100)
+    out_data['nz'], out_data['nz_bins'] = np.histogram(rdz[:, -1], bins=zbins)
+
     save_group(outpath, out_data, out_attrs, None,
                config, save_HOD=True)
     return True

--- a/cmass/nbody/pinocchio.py
+++ b/cmass/nbody/pinocchio.py
@@ -59,7 +59,8 @@ def get_ICs(cfg, outdir):
         logging.info(command)
         os.system(command)
         ic = load_white_noise(path_to_ic, N, quijote=True)
-        os.remove(path_to_ic)  # remove the file
+        if os.path.exists(path_to_ic):
+            os.remove(path_to_ic)  # remove the file
 
     # Convert to real space
     ic = np.fft.irfftn(ic, norm="ortho").astype(np.float32)

--- a/cmass/nbody/pinocchio.py
+++ b/cmass/nbody/pinocchio.py
@@ -31,6 +31,7 @@ from .tools import (
 from .tools_pinocchio import (
     process_snapshot, save_pinocchio_nbody, process_halos, save_cfg_data)
 
+
 @timing_decorator
 def get_ICs(cfg, outdir):
 
@@ -58,6 +59,7 @@ def get_ICs(cfg, outdir):
         logging.info(command)
         os.system(command)
         ic = load_white_noise(path_to_ic, N, quijote=True)
+        os.remove(path_to_ic)  # remove the file
 
     # Convert to real space
     ic = np.fft.irfftn(ic, norm="ortho").astype(np.float32)

--- a/notebooks/build_custom_hod_prior.ipynb
+++ b/notebooks/build_custom_hod_prior.ipynb
@@ -1,0 +1,173 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7f753957",
+   "metadata": {},
+   "source": [
+    "## Build Custom HOD Priors\n",
+    "This file processes saved posterior samples constrained using an observed n(z), and computes a custom prior which is then used in cmass.bias.tools.hod_models."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "793a3889",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
+    "%matplotlib inline\n",
+    "\n",
+    "import os\n",
+    "from os.path import join\n",
+    "import pickle\n",
+    "import json\n",
+    "import h5py\n",
+    "import matplotlib as mpl\n",
+    "import matplotlib.pyplot as plt\n",
+    "# mpl.style.use('../../style.mcstyle')   # noqa\n",
+    "import numpy as np\n",
+    "import torch\n",
+    "import seaborn as sns\n",
+    "import pandas as pd\n",
+    "import warnings\n",
+    "from tqdm import tqdm\n",
+    "\n",
+    "# Suppress warnings\n",
+    "warnings.filterwarnings('ignore')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "48a53370",
+   "metadata": {},
+   "source": [
+    "### MTNG"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "5b5bda67",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(30000, 16)\n"
+     ]
+    }
+   ],
+   "source": [
+    "fname = '/anvil/projects/x-phy240043/x-csui/cmass_data/nz_hod_inference/pos/mtng_hod_pos.npy'\n",
+    "samples = np.load(fname)\n",
+    "print(samples.shape)\n",
+    "\n",
+    "names = [\n",
+    "    'logMmin_z0',\n",
+    "    'logMmin_z1',\n",
+    "    'logMmin_z2',\n",
+    "    'sigma_logM',\n",
+    "    'logM0_z0',\n",
+    "    'logM0_z1',\n",
+    "    'logM0_z2',\n",
+    "    'logM1_z0',\n",
+    "    'logM1_z1',\n",
+    "    'logM1_z2',\n",
+    "    'alpha',\n",
+    "    'mean_occupation_centrals_assembias_param1',\n",
+    "    'mean_occupation_satellites_assembias_param1',\n",
+    "    'eta_vb_centrals',\n",
+    "    'eta_vb_satellites',\n",
+    "    'conc_gal_bias_satellites'\n",
+    "]\n",
+    "samples = pd.DataFrame(samples, columns=names)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "2127df9f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWYAAAFmCAYAAABeJjAWAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvc2/+5QAAAAlwSFlzAAAPYQAAD2EBqD+naQAARBdJREFUeJzt3XdYFWfeP/73oQtSBKQpvUoRrFhiLxEQU4wkktjX/ZpNdKMxa0xs2WeNSXYXjU9MTLJoTEyyNqyxJ4hoBIEjTenShCBioSp1fn/4O+cBaadMO4fP67q4Ls+ZOTMf7pE3N/fM3CNhGIYBIYQQ0dARugBCCCEdUTATQojIUDATQojIUDATQojIUDATQojIUDATQojIUDATQojIUDATQojIUDATQojIUDATQojIUDATQojIUDATQojIUDBrgMLCQkyZMgXLly/H48ePhS6HEMIxCc0uJ36hoaFISEjAkydPMGPGDMTExEBXV1fosgghHKFgFrmSkhI4Oztj+/btsLKywuLFi/G3v/0N27ZtE7o0QghHaChD5I4ePQoDAwOEhoZi2rRpWLduHT799FNkZmYKXRohhCMUzCJ39uxZjBkzBv379wcA/PnPf4aDgwN27NghbGGEEM5QMItYU1MTLl++jAkTJsjfMzAwwKuvvopDhw6hqalJwOoIIVyhYBax5ORkNDQ0YNy4cR3enzVrFmpqanD58mWBKiOEcImCWcTi4uLQv39/+Pv7d3jf19cXAwcOxMWLFwWqjBDCJQpmEbt8+TJGjhwJPT29Du9LJBKMHTuWesyEaCkKZpFqbW3F1atXERwc3OXy4OBgJCcn0w0nhGghCmaRSktLQ21tbbfBPHLkSDQ3N0MqlfJcGSGEaxTMIhUfHw9DQ0MEBgZ2udzHxwfGxsa4du0az5URQrhGwSxS8fHxCAoKgpGRUZfL9fT0EBAQgOvXr/NcGSGEaxTMIsQwDK5cuYJRo0b1uF5QUBAFMyFaiIJZhG7fvo27d+/2GsyBgYEoLi5GVVUVT5URQvhAwSxCsnHj4cOH97je0KFDATy9EYUQoj0omEUoISEB7u7usLS07HE9Z2dnmJqa4saNGzxVRgjhAwWzCCUlJXV7NUZ7Ojo68Pf3p2AmRMtQMItMU1MTUlNTERQUpND6vr6+SEtL47YoQgivKJhF5tatW2hqapKPH/fG19cXeXl5qK+v57gyQghfKJhFRiqVQiKRwNfXV6H1fXx8wDAMbt26xXFlhBC+UDCLTFpaGlxdXWFiYqLQ+t7e3pBIJEhPT+e4MkIIXyiYRSY9PR0+Pj4Kr9+vXz+4uLjg5s2bHFZFCOETBbPIZGZmKjyMIePt7U3PACREi1Awi0hlZSWqqqrg7e2t1Oe8vLyox0yIFqFgFhHZCTwvLy+lPuft7Y3y8nI8evSIg6oIIXyjYBaRW7duQU9PD87Ozkp9Thbk1GsmRDtQMItIVlYWXF1doa+vr9Tn3N3doaOjQ5fMEaIlKJhFJCcnBx4eHkp/ztDQEK6urtRjJkRLUDCLSHZ2Ntzd3VX6rJeXF/WYCdESFMwiUVdXh9LSUpWD2dPTk4KZEC1BwSwSubm5AKDSUAbwtMdcVlZGV2YQogUomEUiJycHANTqMQNPh0MIIZqNglkksrOzYWNjA3Nzc5U+7+7uDolEQsMZhGgBCmaRyMrKUnkYA3g6Z4ajoyOysrJYrIoQIgQKZpFQN5iBp+PTFMyEaD4KZhFoaWlBTk6O0rdiP4sumSNEO1Awi0BBQQGam5tZ6TEXFRXh8ePHLFVGCBECBbMIyKbsVGYe5q54eHiAYRj5FR6EEM1EwSwCmZmZsLa2xsCBA9XaDl0yR4h2oGAWgYyMDKXnYO6KhYUFrK2tKZgJ0XAUzCKQnp6OIUOGsLItT09PujKDEA1HwSyw+vp65OfnUzATQuQomAV28+ZNMAzDajDn5OSgpaWFle0RQvhHwSyw9PR06OjoqH0Ns4yHhweamppQWFjIyvYIIfyjYBZYRkYG3Nzc0K9fP1a2Jwt4utGEEM1FwSyw9PR0Vq7IkLG1tYWZmRk9zYQQDUbBLCCGYZCRkcHa+DIASCQSeHt7UzATosEomAVUUVGB+/fvq33H37O8vLzkdxMSQjQPBbOAMjIyAKh/K/azhgwZguzsbDQ3N7O6XUIIPyiYBZSeng4TExM4Ozuzut0hQ4agqamJ5swgRENRMAtIduJPR4fdwyAbs05LS2N1u4QQflAwC4jNW7HbMzc3h6OjI27cuMH6tgkh3KNgFkhTUxNu3boFX19fTrYfEBCAlJQUTrZNCOEWBbNAbt68iebmZvj5+XGy/cDAQKSkpKCtrY2T7RNCuEPBLJAbN25AIpFw1mMODAxEbW0tTQFKiAaiYBZIcnIyPD09YWJiwsn2g4KCIJFIcO3aNU62TwjhDgWzQJKSkjB06FDOtm9qagpfX19cvXqVs30QQrhBwSyAx48fIzU1FcOHD+d0P6NGjUJ8fDyn+yCEsI+CWQBJSUloaWnByJEjOd3PmDFjkJ+fj7KyMk73QwhhFwWzAC5fvgwzMzPWb8V+1tixYwEAly5d4nQ/hBB2UTAL4LfffsPo0aOhq6vL6X6sra3h5eVFwUyIhqFg5llDQwN+//13TJgwgZf9jRs3DrGxsbzsixDCDgpmnsXGxqKxsRGTJ0/mZX/jxo1DQUEBSkpKeNkfIUR9FMw8O3nyJJydneHu7s7L/mTjzNRrJkRzUDDzqK2tDSdPnsSMGTMgkUh42aelpSX8/f3x22+/8bI/Qoj6KJh5lJKSgvLycjz//PO87nf8+PG4ePEiGIbhdb+EENVQMPMoJiYGlpaWGD16NK/7nTRpEsrLy+lxU4RoCApmnjAMg0OHDmHWrFnQ09Pjdd/BwcEwNjbG6dOned0vIUQ1FMw8uX79OgoKChAeHs77vo2MjDBx4kQcPXqU930TQpRHwcyTb7/9FoMGDcL48eMF2X9YWBgSExNRXFwsyP4JIYqjYObBH3/8gf3792PBggWc3+3Xneeffx7GxsbYv3+/IPsnhCiOgpkH//jHP2BkZISFCxcKVoOJiQlCQ0OxZ88eeqoJISJHwcyxrKwsfP3111i1ahXMzc0FreWNN97A7du3ce7cOUHrIIT0TMLQxa2ceumll5CSkoK4uDgYGhoKWgvDMAgNDYWtrS3Onz8vaC2EkO5Rj5lDycnJOHbsGNauXSt4KAOARCLBihUrcOHCBSQnJwtdDiGkG9Rj5lBoaCjy8vLw22+/CXbS71mtra2YOnUq3N3dcfbsWaHLIYR0gXrMHLl06RLOnDmDtWvXiiaUAUBXVxfr1q3DuXPncPz4caHLIYR0gXrMHGhqasKIESNgaGiI48eP8zZhkaIYhsHixYuRnp4OqVSKQYMGCV0SIaQd6jFz4O9//zuys7Px8ccfiy6Ugadjzf/+97+hr6+PkJAQPHjwQOiSCCHtUDCz7OLFi/j444+xevVq+Pv7C11Ot6ytrbF//36UlZVh1qxZqK6uFrokQsj/j4YyWJSZmYmJEyciICAA+/fvF9XYcncyMzMREREBT09PnDx5EnZ2dkKXREifRz1mFrS2tmLv3r147rnnMGjQIOzevVsjQhkA/P39cfDgQZSUlGDo0KH46aefaN5mQgRGwayGuro67NmzBwEBAVi6dCmmTp2KQ4cOCX6Hn7L8/f1x/vx5BAcH4/XXX0dISAjS0tIooAkRCA1lKKmsrAwXL17EiRMncObMGTx58gTTp0/HX//6VwwbNkzo8tR24cIFbNy4EaWlpbC2tsbw4cMxa9YsTJ06Fa6urjA1NRXlCU1CtAkFcxcYhkFtbS1SU1Mxb948VFZWdrvutGnTtO5ys+bmZly7dg1FRUVqbcfd3R0HDhyAp6cnBTohSqBg7kJNTY3GDUeIXXV1NczMzIQugxCNQMHcBVmPub2amho4OjqitLSUAkYBz7YX9ZgJURy/D5/TEBKJpNvwNTMzo2BWArUXIcqjqzIIIURkKJgJIURkKJgVZGhoiM2bN4tiXmVNQO1FiOro5B8hhIgM9ZgJIURkKJgJIURkKJgJIURkNC6YL1++jPDwcDg4OEAikeDYsWPdrrtixQpIJBLs2LGDt/oIIURdGhfM9fX1CAwMxK5du3pc7+jRo0hISICDgwNPlRFCCDs07s6/kJAQhISE9LhOWVkZVq5ciXPnziEsLKzXbTY2NqKxsVH+mmEYNDU1wdramm4jJoTwTuN6zL1pa2vDggUL8N5778HPz0+hz2zbtg3m5ubyLwsLC9jY2HSaL4MQQvigdcH86aefQk9PD6tWrVL4M+vXr0d1dbX8q7S0lMMKCSGkZxo3lNGTlJQUfP7555BKpUoNQRgaGtIdaoQQ0dCqHnN8fDwqKyvh5OQEPT096Onpobi4GO+++y5cXFyELo8QQhSiVcG8YMECpKenIzU1Vf7l4OCA9957D+fOnRO6PKKFGIbBmjVrMGnSJJSXlwtdDtESGjeUUVdXh/z8fPnrwsJCpKamwtLSEk5OTrCysuqwvr6+Puzs7ODt7c13qaQPiI+Px/bt2wE8PVexb98+gSsi2kDjeszJyckYNmyY/MGna9aswbBhw7Bp0yaBKyN90f79++Hs7IyNGzfip59+QkVFhdAlES1As8t1QfbMP3pOHemNq6srpk2bhjVr1mDUqFFYt24ddRKI2kTRY3748CG+//57ocsgRCl37txBUVERxo4dCwsLC8ydOxdffvllh5uVCFGFKIK5pKQES5YsEboMQpSSmJgIAPJhtWXLluHu3bs9zt9CiCJ4OflXU1PT43K6w45oopSUFNjZ2cHOzg4A4OnpiWHDhuHQoUN49dVXBa6OaDJegtnCwqLHGz4YhqE5KYjGkUql8Pf37/DetGnT8M0336C1tRW6uroCVUY0HS/BbGpqig8//BDBwcFdLs/Ly8P/+3//j49SCGEFwzCQSqVYsGBBh/fHjBmDf/3rX8jMzERgYKBA1RFNx0swDx8+HAAwadKkLpdbWFiALg4hmqSsrAz37t3r1GMODAyERCJBSkoKBTNRGS8n/yIjI2FkZNTtcjs7O2zevJmPUghhRUpKCgAgICCgw/vGxsZwd3fHjRs3hCiLaAleeszLly/vcbmtrS0FM9EoSUlJsLGxgb29fadl3t7euHnzpgBVEW3B6+VyJSUlXV7j2dbWhpKSEj5LIUQtSUlJGDp0aJcnrT09PZGVlSVAVURb8BrMLi4uGD58OAoKCjq8f+/ePbi6uvJZCiEqYxgGycnJCAoK6nK5p6cnKioq8OjRI17rItqD9xtMhgwZgtGjR+PXX3/t8D6d/COaoqioCA8ePMDQoUO7XO7u7g7g6dVGhKiC12CWSCT48ssvsWHDBoSFhWHnzp0dlhGiCbo78Scj++svNzeXt5qIduF12k9Zr3j16tXw8fHB/PnzkZGRQZO+cODZUPDy8hKoEu2TlpYGGxsb2NjYdLm8f//+sLGxoWAmKhNsPuaQkBD8/vvvmDNnDq5fvy5UGRpNmR/87talwFZeWloafH19e1zH1dWVhjKIyngdypg0aRIMDAzkr319fZGYmEg3mCgpNzeXtd4Ym9vqKzIyMuDj49PjOi4uLhTMRGW8BnNsbCwsLCw6vGdlZYW4uDi0tbXJ3/vkk0/ojHYXuAxRCmfF1NXVoaioqNcn4ri5uSEvL486HEQlopj281kff/wxHjx4IHQZokG9WvG4desWAPQazK6urqiurkZVVRUfZREtI8pgpl7GU3wHMoV/727dugWJRNLr2LybmxsAICcnh4+yiJYRZTATCkmxunnzJhwdHdGvX78e13NxcQFA1zIT1VAwi5CQoUy/EHqWmZmp0BPX+/Xrh8GDB1OPmaiEgllkKBjF7ebNmwoFM/B0OIOCmahCsOuYSUeqBHJqamq3y7qbx6E3dF1z9x49eoTS0lKF28jNzQ1JSUkcV0W0kSiDecKECb2O4WkTZUK5fRhbWVl1uc79+/fl66ka0KQz2VSevV3DLOPu7o6ff/6ZHjNFlMZ7MLe1tSE/Px+VlZUdrl0GgIkTJwIATp8+zXdZglE0lBUJ5GeX379/X6laqLfcs8zMTOjq6sonKeqNq6srGhsbUVJSQrMnEqXwGswJCQmIjIxEcXFxp0viJBIJWltb+SxHcIqEsiyQewvjnj5PvWZ2ZGZmws3Nrcen8bQnu2QuLy+PgpkohdeTfytWrMDIkSORmZmJBw8e4OHDh/KvvnZDCR+hrOrnSNcyMzPh6emp8PqDBg2Cvr4+XTJHlMZrjzkvLw+HDx+Gh4cHn7sVHT5CWVk0jNG7W7du4Y033lB4fT09PTg7OyM/P5/Dqog24rXHHBwc3Of/k/IZysqOMZPuVVVVobKyUulfYC4uLn3+/zxRHq895pUrV+Ldd99FRUUFAgICoK+v32F5d0+E0Ba9hTIXvWRFxpept9w72RwZyraVs7Mzrly5wkVJRIvxGsxz584FACxdulT+nkQiAcMwWn/yj+9QVrS3TKGsmKysLOjq6ip9Es/V1RU//PADXTJHlMJrMBcWFvK5O9EQoqcM0DXMbMrOzoaLi0uH+cQV4eLigqamJty5cwfOzs4cVUe0Da/B3Bf/YwoVyoqg3rLisrOzFb5+ub32kxn1xf//RDWcn/w7ceIEmpub5f/u6UsRly9fRnh4OBwcHCCRSHDs2LEOy7ds2QIfHx+YmJhgwIABmD59OhITE9n+thSi6M0jbIfy/fv3e+0tUygrJzs7W6WriQYPHgxdXV06AUiUwnmP+cUXX0RFRQVsbGzw4osvdrueomPM9fX1CAwMxNKlS/Hyyy93Wu7l5YUvvvgCbm5uePz4MbZv346ZM2ciPz8fAwcOVOdbUYoyV1+wSZGxZQpl5Tx58gTFxcUq9Zj19fXh7OxM1zITpXAezO1vu372FmxVhISEICQkpNvlkZGRHV5HRUUhOjoa6enpmDZtmtr7ZwsXQxiyUO6pt0yhrDzZI6JUCWbg6QlAmjWQKEOUkxixpampCd988w3Mzc0RGBjY7XqNjY1obGyUv66pqVFrv0INYQB0wo8L2dnZAKBWMMfHx7NZEtFyvAdzUlISYmNju5zEKCoqipV9nDp1Cq+99hoaGhpgb2+PCxcuwNrautv1t23bho8++oiVfQs5hEHjytzIzc2FhYUFLC0tVfq8q6sr9u3bh5aWFujpaXVfiLCE1/8lH3/8MTZs2ABvb2/Y2tpCIpHIl7X/t7qmTJmC1NRUVFVV4dtvv0VERAQSExNhY2PT5frr16/HmjVr5K9ramrg6OjIWj1d4WIIoycUyqrLyclRubcMPJ3MqLm5GUVFRX1+OgKiGF6D+fPPP8eePXuwePFiTvdjYmICDw8PeHh4YMyYMfD09ER0dDTWr1/f5fqGhoYwNDTktCauKDKuTNSTm5srnylOFbJQz83NpWAmCuF1rgwdHR2MHz+ez10CeHrSsf0YsrZQNJSpt6w6hmHU7jHb29ujX79+9JgpojBeg3n16tXYtWuXWtuoq6tDamqqfJy2sLAQqampKCkpQX19PT744AMkJCSguLgYKSkpWLp0KcrKyjBv3jwWvoOe8XnmnXrK/KiqqsKjR4/U6jHr6OjQlRlEKbwOZaxduxZhYWFwd3eHr69vp0mMYmJiet1GcnIypkyZIn8tGxtetGgRdu/ejezsbOzbtw9VVVWwsrLCqFGjEB8fDz8/P3a/GTXdv39fpXFmZQOZesvqkfVy1Qlm2ecpmImieA3mVatWITY2FlOmTIGVlZVKJ/wmT57c6ekn7SkS7kILCgpCamqqUuHc/gQfhTJ/cnJyIJFI5LdWq8rNzQ1Hjhxhpyii9XgN5n379uHIkSMICwvjc7e8ULY3pGg4qxLIAIUyW3JycjB48GC1Hw7s7u6OsrIy1NXVoX///ixVR7QVr8FsaWmp1kkUsVL1T1RZ0PZ0XbMqY8gUyuzJyclRexgD6HhlxvDhw9XeHtFuvAbzli1bsHnzZuzduxfGxsZ87lrU2DyBR6HMruzsbEyYMEHt7ciCOTs7m4KZ9IrXYN65cycKCgpga2sLFxeXTif/pFIpn+UQ0qOmpibcvn0bS5YsUXtbZmZmsLGxoUvmiEJ4DeaeZpcj6qPeMrvy8/PR0tLCWrt6eHggKyuLlW0R7cZrMG/evJnP3fUpFMrsk4Wop6cnK9vz8PCgvwqJQni9wURbCR2KQu9fW2VmZsLKyoq1eU28vb2Rk5ODlpYWVrZHtBcvPWZFz2rfvn2b40q44+XlJcgNBBTK3MnIyICPjw9r2/P09ERzczPy8/NZ3S7RPrwEc1FREZydnREZGdntDG/agO9wplDmVkZGBitXZMjIwjgzM5OCmfSIl2A+cOAA9uzZg6ioKISEhGDp0qUIDQ2Fjo72jaTIwpLrgKZQ5lZdXR3y8vKwYsUK1rZpZWUFa2trZGRk4JVXXmFtu0T7SJie7m9mWVlZGb777jt89913aGhowIIFC7Bs2TLWTq6wpaamBubm5qiuroaZmRmr21Y3sCmQ+XHlyhVMmDAB586dg7+/P2vbfe2112BlZYWjR4+ytk2ifXjtsg4aNAgffvgh8vLy8NNPPyExMRE+Pj54+PAhn2UIysvLS6VwVfVzRDVJSUkwMjKCt7c3q9sdMmQI0tLSWN0m0T68jyU8efIE+/fvx0cffYTExETMmzevT94FqEzQUiDz7/r16/D39+90E5S6/Pz8UFhYiEePHrG6XaJdeLuOOTExEdHR0Th48CDc3NywdOlSHDlyBAMGDOCrBFGi0BWn33//vcensatKNiySmpqKyZMns759oh14CWY/Pz9UVlYiMjIScXFxPT6xmhChlZSUoKSkBKNHj2Z92x4eHujXrx+kUikFM+kWL8GclZUFExMTfP/99/jhhx+6Xe/Bgwd8lENIj2JjYyGRSBAcHMz6tvX09ODr64uUlBTWt020By/BvHfvXj52Qwgrzp8/D39/f86G2QIDAxEfH8/Jtol24CWYFy1axMduCFFba2srzp8/j9dee42zfQwbNgx79uzBgwcPYGlpydl+iObSvjs8CFFDYmIiqqqqMH36dM72IZuP+dq1a5ztg2g2XoN5wIABsLS07PRlZWWFQYMGYdKkSTTsQQR18uRJWFtbczqZvbOzM2xsbHDlyhXO9kE0G6/Tfm7atAlbt25FSEiI/Iz39evXcfbsWbz11lsoLCzEm2++iZaWFixfvpzP0ggBAJw4cQJTp06Frq4uZ/uQSCQYM2YMYmNjOdsH0Wy8BvOVK1fwj3/8o9P8A19//TXOnz+PI0eOYOjQodi5cycFM+FdUVERbt26hXfeeYfzfU2YMAHr1q1T6knppO/gdSjj3LlzXY7dTZs2DefOnQMAhIaGavT0n0Rz/fLLL9DT08PEiRM539fUqVPR1taGX375hfN9Ec3DazBbWlri5MmTnd4/efKk/Ox0fX09TE1N+SyLEADA6dOnERwczMv/Pzs7O4waNQr//e9/Od8X0Ty8DmVs3LgRb775JmJjY+VjzElJSTh9+jR2794NALhw4QImTZrEZ1mEoKGhAb/99hvee+893vb5yiuvYP369bhz5w4GDx7M236J+PE67ScAXL16FV988YX8acHe3t5YuXIlxo0bx2cZPeJy2k8iTidOnMALL7yAuLg4eHh48LLP2tpajBgxAn/729+wadMmXvZJNAPvwawJKJj7noULFyIhIQGXLl3idb/vvfcerl69itu3b2vlgyOIangdygCe3ll17Ngx+ROI/fz8MGfOHE4vTyKkJw0NDTh69CirTytRVEREBH766SfEx8fTEB6R4zWY8/PzERoairKyMvkE5Nu2bYOjoyN++eUXuLu781kOIQCAgwcPoq6uDnPnzuV93yNHjoSjoyP++9//UjATOV7/dlq1ahXc3d1RWloKqVQKqVSKkpISuLq6YtWqVXyWQggAgGEY7NixA1OnToWTkxPv+5dIJAgPD8eRI0fQ0tLC+/6JOPEazHFxcfjss886TNxiZWWFTz75BHFxcXyWQggA4PDhw0hLS8Nbb70lWA3h4eG4d+8efvvtN8FqIOLCazAbGhqitra20/t1dXUwMDDgsxRC8OjRI6xevRozZszAmDFjBKsjICAA7u7uPc5VTvoWXoN59uzZ+POf/4zExEQwDAOGYZCQkIAVK1Zgzpw5fJZC+jiGYbBixQrU1tZi69atgtYikUgQERGBw4cPo6qqStBaiDjwGsw7d+6Eu7s7xo4dCyMjIxgZGWHcuHHw8PDAjh07FNrG5cuXER4eDgcHB0gkEhw7dky+rLm5GevWrUNAQABMTEzg4OCAhQsXory8nJtviGisH3/8EQcOHMAnn3yCQYMGCV0OIiMjoaOjg3/+859Cl0JEgNdgtrCwwPHjx5Gbm4vDhw/j8OHDyM3NxdGjR2FhYaHQNurr6xEYGIhdu3Z1WtbQ0ACpVIqNGzdCKpUiJiYGOTk51BsnHdy5cwcrV67Eyy+/jBdeeEHocgA8na7gL3/5C/7973/L540hfRfnN5isWbNG4XWjoqKU2rZEIsHRo0fx4osvdrtOUlISRo8ejeLi4m7Pujc2NqKxsVH+uqamBo6OjnSDiRaqrq7GzJkzcefOHVy4cEHhDgEfWlpasGzZMsTFxWHHjh148803IZFIhC6LCIDz65hv3Lih0Hpc/Qesrq6GRCLp8Qdw27Zt+OijjzjZPxFeY2Mjbt26hcuXL2P79u14+PAhDhw4IKpQBp4+qPU///kP/v73v+Ott97CqVOn8MUXX8DNzU3o0gjPNPqW7N56zE+ePMH48ePh4+ODH3/8sdvtUI9Zu7S1taGiogJXr17F999/j/Pnz6OpqQn6+vqYOXMmPvjgA7i4uAhdZo8uXLiADz74AFVVVViyZAkiIiLg5uYGBwcHuoKpD9DaYG5ubsbcuXNx584dXLp0SamAra6uhoWFBUpLSymYWWJqaqrQX0UMw6C2thY///wzq7dI+/j4wNvbG8bGxqxtk2sNDQ04fvy4yp8/fvw4Jk+erHDbE/Hgfa4MPjQ3NyMiIgLFxcX47bfflA5X2bXWjo6OXJTXJyn610dtbS3Mzc1Z3392djays7NZ366YyU5s0l9+mkfrglkWynl5eYiNjVXpsT0ODg4oLS3t0NOQDW9QL1oxz7aXopPPm5qaorq6mtpbTe3bjx48oXk0Lpjr6uqQn58vf11YWIjU1FRYWlrC3t4er7zyCqRSKU6dOoXW1lZUVFQAeHo5kqJjczo6Ot1OXG5mZkZBoQRl20sikXRYn9pbPWZmZjSMoYE0LpiTk5MxZcoU+WvZ5XiLFi3Cli1bcOLECQBAUFBQh8/FxsZi8uTJfJVJCCEq07hgnjx5Mno6X6nB5zIJIQQAz3f+aTJDQ0Ns3rwZhoaGQpeiEdRtL2pv9VD7aTaNvlyOEEK0EfWYCSFEZCiYCSFEZCiYCSFEZCiYCSFEZCiYCSFEZCiYu8AwDGpqauiaaAFQ2xNCwdwl2UQ6XT04lnCL2p4QCmZCCBEdCmZCCBEZCmZCCBEZCmZCiGgVFBRg/PjxmDRpUofpfrUdBTMhRJQYhsHixYtRWlqKkpISvPbaa33mah2Nm/aTENI3JCUl4cqVK9i7dy+MjIwwf/58JCYmYsyYMUKXxjkKZkKIKP3www+ws7PDtGnTAABWVlY4efJknwhmlYYy2traun2/pKRErYIIIaStrQ0xMTEICwuDrq4udHV1ERwcjPj4eKFL44VSwVxTU4OIiAiYmJjA1tYWmzZtQmtrq3z5vXv34OrqynqRhJC+5caNGygvL8esWbPk740YMQLJyckdMkdbKRXMGzduRFpaGn744Qds3boV33//PV544QU0NTXJ1+krg/OEEO6cP38e/fv3x6hRo+TvDR06FI8fP0Z2draAlfFDqWA+duwYvv76a7zyyiv405/+hOTkZNy7dw/h4eFobGwEAHoiLyFEbZcuXUJwcDD09fXl7/n5+QEA0tLShCqLN0oF87179+Ds7Cx/bW1tjYsXL6K2thahoaFoaGhgvUBCSN/S1taGhISEDr1lADA3N8fgwYORnp4uUGX8USqYnZyckJWV1eE9U1NTnD9/Ho8fP8ZLL73EanGEkL4nLy8PNTU1CAwM7LTM29sbGRkZAlTFL6WCeebMmdi7d2+n9/v3749z587ByMiItcIIIX2TrEcsG7poz8vLCzdv3uS7JN4pdR3zRx99hPLy8i6XmZqa4sKFC5BKpawURgjpmzIyMmBjYwMrK6tOy7y8vPDVV1+hrq4O/fv3F6A6fijVYx4wYAD8/PxQUlIiP9nXXv/+/elyOUKIWrKzs+Hp6dnlMtn7ubm5fJbEO5VuMHFxccHw4cNRUFDQ4f3KykoKZkKIWnJycuDm5tblMnd3dwDodK5L26g8idGQIUMwevRo/Prrrx3ep+uYCSGqYhgG+fn53XbwzMzMMHDgQOTl5fFcGb9UCmaJRIIvv/wSGzZsQFhYGHbu3NlhGSGEqKKiogINDQ1wcXHpdh1XV1etD2aVJjGS9YpXr14NHx8fzJ8/HxkZGdi0aROrxRFC+hbZ8Gj7+yWe1ReCWe35mENCQvD7778jNjYWs2fPZqMmQkgfVVhYCODpPRPdcXZ2lq+nrVQK5kmTJsHAwED+2tfXF4mJibCwsKAxZkKIyoqKimBtbQ1jY+Nu13F2dkZVVRVqamp4rIxfKgVzbGwsLCwsOrxnZWWFuLi4DlOCfvLJJ3j06JE69RGitXJzc+Vf5KmioiIMHjy4x3VkvelnrwrTJpw+Wurjjz/GgwcPuNwFUUD7AKAgEF5Xx4COyVOKBLNs/FmbhzM4fYIJDWsIq6cfdtkyLy8vvsrp8yh8e1dSUoLp06f3uI6lpSVMTEy0usdMj5bSEqr+0Ofm5lI4c0zRY9PXj4XsCUiDBg3qcT2JRKL1JwDpKdkajo2hCerJcYfaVnGVlZVoamrqNZiBp8MZ2txjpmDWYGz+0FOAsEvVX5h9+TjInheqSDA7OTlRMHPl8uXLCA8Ph4ODAyQSCY4dO9Zh+ZYtW+Dj4wMTExMMGDAA06dPR2JiYo/b3LJlCyQSSYcvHx8fDr8L/tEJPPGiv2BUp0wwu7q6oqioqMNj7bQJp8E8YcIE9OvXr9vl9fX1CAwMxK5du7pc7uXlhS+++AIZGRm4cuUKXFxcMHPmTNy7d6/H/fr5+eGPP/6Qf125ckWt70MsKJDFjY6NekpKSmBiYtLpUtyuuLm5obW1Fbdv3+a+MAGofPKvra0N+fn5qKys7HDtMgBMnDgRAHD69OketxESEoKQkJBul0dGRnZ4HRUVhejoaKSnp2PatGndfk5PTw92dna9fQtyjY2NHaYxFdOF69r+wy7mtleGth8nPpSWlsr/eu6NbJa57OxsrfuLGFAxmBMSEhAZGYni4uJOl8RJJBJOHi/e1NSEb775Bubm5l0+cqa9vLw8ODg4wMjICGPHjsW2bdt6vMVz27Zt+Oijj9guWS18/6ALdTWAGNteWRTK7CgpKYG9vb1C69ra2sLc3By3bt3Ciy++yG1hAlBpKGPFihUYOXIkMjMz8eDBAzx8+FD+xfYNJadOnUL//v1hZGSE7du348KFC7C2tu52/eDgYHz33Xc4e/YsvvrqKxQWFmLChAmora3t9jPr169HdXW1/Ku0tJTV70FZQvygCxUuYmt7ZVEos0fWY1aERCKBt7c3MjMzOa5KGCr1mPPy8nD48GF4eHiwXU8nU6ZMQWpqKqqqqvDtt98iIiICiYmJsLGx6XL99kMjQ4cORXBwMJydnXHw4EEsW7asy88YGhrC0NCQk/qV1dd+0MXU9srqa8eKa6WlpZgwYYLC6/v5+eHatWscViQclXrMwcHByM/PZ7uWLpmYmMDDwwNjxoxBdHQ09PT0EB0drfDnLSws4OXlxVu9qqITe5qFy2PVF28yaWpqwt27dxW6IkMmICAAOTk5Pf41rKlU6jGvXLkS7777LioqKhAQEAB9ff0Oy4cOHcpKcV1pa2vr8nmD3amrq0NBQQEWLFjAWU3qUvWHPDU1tdN7QUFB6hVDeqXM8Xr2GNHx6VpZWRkYhlF4KAMAAgMDwTAMpFIpJk2axGF1/FMpmOfOnQsAWLp0qfw9iUQChmGUOvlXV1fXoSdbWFiI1NRUWFpawsrKClu3bsWcOXNgb2+Pqqoq7Nq1C2VlZZg3b578M9OmTcNLL72Et99+GwCwdu1ahIeHw9nZGeXl5di8eTN0dXUxf/58Vb5Vzikbys/+oD/7JOH2yykE2KXoseruGN2/fx+pqak9Hpe+2FsGID+3oEwwe3p6wsTEBAkJCRTMAHuzOiUnJ2PKlCny12vWrAEALFq0CLt370Z2djb27duHqqoqWFlZYdSoUYiPj4efn5/8MwUFBaiqqpK/vnPnDubPn4/79+9j4MCBeO6555CQkICBAweyUjObVO15dfVY92eXKRIC7fXVQFCUIseqt2NkZWWF+/fvs1mW1pAFs6JXZQCArq4uAgMDe73pTBOpFMw9PfZFGZMnT+5xBrqYmJhet1FUVNTh9X//+191y+KFKr2vngL5WRQC7FEmlJU5RuT/lJSUwNzcHCYmJkp9btiwYTh+/DhHVQlH4WA+ceIEQkJCoK+vjxMnTvS47pw5c9QuTJspG8r0wy5ubB2nvvxXizKXyrUXEBCAXbt24e7du7C1teWgMmEoHMwvvvgiKioqYGNj0+MF3VzdYKItxBjKfTkQetPb8aJfnuwoLS1V6ooMGX9/fwBPj8Pzzz/PdlmCUfhyuba2Nvm1w21tbd1+USh3T4yhTLrHZyj39V+OiszD3BVnZ2eYmJggLS2Ng6qEQ9N+8kSZULaysuItlPt6IHSHi1C+f/8+XSnTjZKSEpWGMnR0dLTyDkCVJzFKSkpCbGxsl5MYRUVFqV2YtlD2ygu2AlmRE38Uyp0JcaKvrx+H6upqPHr0CI6Ojip93tPTE7du3WK5KmGpFMwff/wxNmzYAG9vb9ja2naYDUqRmaH6AlWuT2a7l0y9M/apepzoCpnuFRcXA1BsHuaueHl54eTJk/L7KLSBSsH8+eefY8+ePVi8eDHL5WgHdW8a4UNf76V1RZHhC3V+edIvyq7Jgrm3p2N3x83NDQ0NDSgrK1N5G2Kj0hizjo4Oxo8fz3YtfRIXJ/qod6Y8RceUVdHT8aBfkMDt27dhZGSk8uVussnUcnJy2CxLUCoF8+rVq7t96khfp8rdfFyc6KPemeL4uPqiq+NBofzU7du34ejoqPIwhKOjI3R1dZGXl8dyZcJRaShj7dq1CAsLg7u7O3x9fTtNYqTIHXvkKbZDmXrLylH0F6mqx4mOR+9kwawqfX19ODk5aVUwq9RjXrVqFWJjY+Hl5QUrKyuYm5t3+OrLFO0FcTmu3FtvmXpqilNnXFkWytRb7ll+fj5cXV3V2oarq6tWBbNKPeZ9+/bhyJEjCAsLY7sejafMUIYQvWUKhP/D5biyDA0p9Uz2QNXXX39dre24uLggISGBpaqEp1KP2dLSUv4wRKI8LnrLPfXOiOq4GMKgX47/586dO2hqaoKLi4ta23FxcUFBQUGneyo0lUrBvGXLFmzevBkNDQ1s16PRhOotKxrKFAj/h8snkNAQhuJkx8HNzU2t7bi4uKCxsRFlZWVslCU4lYYydu7ciYKCAtja2sLFxaXTyT+pVMpKcZpE6MdCUSizS90bSegvF8Xk5uZCX19f7euPZT3u/Px8tU4kioVKwayNjwvXRNRTFpfejgcdh85ycnLg4uICPT2VZ4cA8PSSOR0dHeTl5XV4+IamUqk1Nm/ezHYdfc79+/fVGs6gnpm4UCirJjc3V+1hDAAwMDCAo6Oj6B+6rCiaXY4Fyg5jyH54Vb3GVZlQpkDojO1hJwpl1eXk5LB2IYGrq6vgQ4psUarHrOhvttu3b6tUTF8SFBSE1NRUhXvO7UOcnuPHj96OjSK/IOkYdK+hoQHFxcXyW6rV5ebmhqtXr7KyLaEpFcxFRUVwdnZGZGSkfNJ8ojpFwlmVQAYoELqjaI+qp2Oj6DGhY9Cz3NxcMAzDWo/Zw8MD33//PZqbmztdkKBplArmAwcOYM+ePYiKikJISAiWLl2K0NBQ6Oj07RERLy8vlf+Eah8APa2jTC2EHT0dGxrbV59sDmVPT09Wtufp6YmWlhbk5+djyJAhrGxTKEol6rx583DmzBnk5+djxIgRWL16NRwdHfH++++rdDvk5cuXER4eDgcHB0gkEhw7dqzD8i1btsDHxwcmJiYYMGAApk+frtCjynft2gUXFxcYGRkhODgY169fV7o2PgUFBfX4Rdij7C8uVY8J/YLs3c2bN2Fvb8/aNA7e3t4AoBVPM1Gpqzto0CB8+OGHyMvLw08//YTExET4+Pjg4cOHSm2nvr4egYGB3c5U5+XlhS+++AIZGRm4cuUKXFxcMHPmTNy7d6/bbR44cABr1qzB5s2bIZVKERgYiOeffx6VlZVK1aYsMfwgiqEGQsdBUZmZmay2lZWVFQYOHIiMjAzWtikUlS8efPLkCQ4fPow9e/YgMTER8+bNg7GxsVLbCAkJQUhISLfLIyMjO7yOiopCdHQ00tPTMW3atC4/ExUVheXLl2PJkiUAgN27d+OXX37Bnj178P777ytVnyahMBAeHQPlZGRkYObMmaxu09fXV5AHT7BN6WBOTExEdHQ0Dh48CDc3NyxduhRHjhzBgAEDuKhPrqmpCd988w3Mzc0RGBjY7TopKSlYv369/D0dHR1Mnz4d165d63bbjY2NaGxslL+uqalhr3AeaHIgaHrby2jyMRBCTU0NCgsL4ePjw+p2/f39Ow2JaiKlhjL8/Pwwe/Zs9OvXD3FxcZBKpXj77bc5DeVTp06hf//+MDIywvbt23HhwgVYW1t3uW5VVRVaW1s7PQnB1tYWFRUV3e5j27ZtHaYtVfWWTr5/OL28vDQ+ENhqe2Ww3WaafgyEkJ6eDuBpkLIpKCgIZWVlGj9nhlLBnJWVhSdPnuD777/HlClTYGlp2eUXm6ZMmYLU1FT8/vvvmDVrFiIiIlgfL16/fj2qq6vlX6WlpSpvSxaWXP6wakMgy7DZ9kLQluPAN6lUCgMDA9auYZYZPnw4APT4F7ImUGooY+/evVzV0S0TExN4eHjAw8MDY8aMgaenJ6KjozsMV8hYW1tDV1cXd+/e7fD+3bt3YWdn1+0+DA0NYWhoyHrt6lxG1932tA1Xbd8bdY6NNh4HvkmlUgwZMgQGBgasbtfOzg6urq64dOkSXnnlFVa3zSelgnnRokVc1aGwtra2DmOS7RkYGGDEiBH49ddf5RMttbW14ddff8Xbb7/NY5X/h41wpiDghrLHho4De5KSkjBixAhOtj1u3DhcvHiRk23zRb0pndRUV1fXYdKRwsJCpKamwtLSElZWVti6dSvmzJkDe3t7VFVVYdeuXSgrK8O8efPkn5k2bRpeeuklefCuWbMGixYtwsiRIzF69Gjs2LED9fX18qs0hPDsD7SiYUBBwD1ZG/d0TOg4sKu2thZZWVlYtmwZJ9ufMmUKfvzxRxQUFGjsAz1UCuYBAwZ0+URbiUQCIyMjeHh4YPHixb2GYXJycocp+tasWQPgac989+7dyM7Oxr59+1BVVQUrKyuMGjUK8fHx8PPzk3+moKAAVVVV8tevvvoq7t27h02bNqGiogJBQUE4e/asyo9G50JvYUBBwL/2x4Tan1spKSlgGIazm6cmTpwIAwMDnDhxAqtXr+ZkH1yTMAzDKPuh7du3Y+vWrQgJCcHo0aMBANevX8fZs2exevVqFBYW4ocffsD//u//Yvny5awXzbWamhqYm5ujuroaZmZmQpfTp1Dba7/PPvsMf//735GVlQVdXV1O9rFw4UI0NzcjLi6Ok+1zTaUe85UrV/CPf/wDK1as6PD+119/jfPnz+PIkSMYOnQodu7cqZHBTAjhTmJiIgIDAzkLZQCYNWsW1q1bh3v37mHgwIGc7YcrKt2Sfe7cOUyfPr3T+9OmTcO5c+cAAKGhoTT9JyGkA4ZhkJCQwPkcMDNmzADDMDhx4gSn++GKyk/JPnnyZKf3T548Kb+Oub6+HqampupVRwjRKiUlJSgvL8fIkSM53c/AgQMxevRoxMTEcLofrqg0lLFx40a8+eabiI2NlY8xJyUl4fTp09i9ezcA4MKFC5g0aRJ7lRJCNJ5sInuugxkAwsLC8D//8z94+PAh51NGsE2lHvPy5csRFxcHExMTxMTEICYmBsbGxoiLi5NfAvPuu+/iwIEDrBZLCNFscXFx8PT0VOt5l4qaPXs2WltbcfjwYc73xTaVrsrQdnRlgHCo7bWbh4cHJkyYgK1bt/KyvzfeeAMNDQ1ISEjgZX9sUfkGk9bWVhw7dgxZWVkAnk5wNGfOHE7PtBJCNFdubi4KCgqwYcMG3vb5+uuv409/+hNSUlI4u9OQCyoNZcge3bJw4UL5UMYbb7wBPz8/FBQUsF0jIUQLHD16FP369cNzzz3H2z5nzJgBJycnfPbZZ7ztkw0qBfOqVavg7u6O0tJSSKVSSKVSlJSUwNXVFatWrWK7RkKIhmMYBvv378e0adOUfqCGOvT09PDWW2/h0KFD8qlGNYFKY8wmJiZISEhAQEBAh/fT0tIwfvx41NXVsVagEGicUzjU9trp6tWreO6557B///4O0zDwobm5GVOnToW3tzdOnz7N675VpVKP2dDQELW1tZ3er6urY30aP0KI5vvnP/8JDw8PQS6h1dfXx3vvvYczZ85ozC3aKgXz7Nmz8ec//xmJiYlgGEZ+N8+KFSswZ84ctmskhGiwGzdu4Pjx4/jLX/4CHR2VIkdt4eHhCAwMxNq1a9HW1iZIDcpQqZV27twJd3d3jB07FkZGRjAyMsK4cePg4eGBHTt2sFwiIURTtba24p133oGHhwfmzp0rWB0SiQQfffQRkpOTsW3bNsHqUJRKl8tZWFjg+PHjyM/Pl18uN2TIENYfE0MI0VxtbW1YvXo14uPjceDAAejpCTr9O0aNGoU1a9Zgw4YNyMrKws6dO1l/FB5bFD75J5srWRFRUVEqFyQGdAJKONT22qGpqQlLlizBzz//jG3btmHBggVClwTg6dUhhw8fxubNm2FhYYEDBw4gODhY6LI6UfhX2I0bNxRar6sJ9AkhfUdtbS0iIiLw66+/4quvvkJ4eLjQJclJJBLMmzcPY8eOxYoVKzBu3Di8/fbb2LRpEy+3iSuKbsnuAvXahENtr3mePHmChw8forKyEklJSfj0009RUVGBb7/9FhMnThS6vG41NzfjP//5D7Zv346WlhaMGTMGo0aNgre3N5ydnREQENDjQ5y5RMHcherqalhYWKC0tJTCgSWmpqYK/TVFbc8+RdueYZgOl8FWVFQgIiICaWlpSu9zxIgRcHFxUfpzQnjw4AFiY2PV3k5kZCR27drV4coTRdv+WRTMXbhz5w4cHR2FLkOrKNoDprZnn6JtL/trhbBH1b/8KJi70NbWhvLy8g6/7WpqauDo6Eg9OQU9216K9hxkbc8wDJycnKi9VdS+/QcNGqRSj5nLmrTxmHb1/anaYxb2+hWR0tHRweDBg7tcZmZmppX/qbiibHvJ2r6mpkalz5OOzMzMFA4GiUTCS1tr+zFl4/sT5jYcQggh3aJgJoQQkaFgVpChoSE2b94MQ0NDoUvRCOq2F7W3esTYfmKsiU1sfn908o8QQkSGesyEECIyFMyEECIyFMyEECIyFMyEECIyFMzPuHz5MsLDw+Hg4ACJRIJjx47JlzU3N2PdunUICAiAiYkJHBwcsHDhQpSXlwtXsMB6aq9nrVixAhKJpMPDFKi91aNu+wtR05YtW+Dj4wMTExMMGDAA06dPR2JiIqc1sYmPNqdgfkZ9fT0CAwOxa9euTssaGhoglUqxceNGSKVSxMTEICcnp08/Tqun9mrv6NGjSEhIgIODg8Kfp/bunbrtL0RNXl5e+OKLL5CRkYErV67AxcUFM2fOxL179zivjQ28tDlDugWAOXr0aI/rXL9+nQHAFBcX81OUiHXXXnfu3GEGDRrEZGZmMs7Ozsz27duV+nx71N7dU7f9+aypverqagYAc/HiRX6KYhFXbU49ZjVVV1dDIpHAwsJC6FJEqa2tDQsWLMB7770HPz8/tbdH7a0cttufbU1NTfjmm29gbm6OwMBAocthBRttTpMYqeHJkydYt24d5s+fr9WTsqjj008/hZ6eHlatWqX2tqi9lcdm+7Pp1KlTeO2119DQ0AB7e3tcuHAB1tbWQpfFCjbanIJZRc3NzYiIiADDMPjqq6+ELkeUUlJS8Pnnn0Mqlar9yDFqb+Wx2f5smzJlClJTU1FVVYVvv/0WERERSExMhI2NjdClqYWtNqehDBXIQqK4uBgXLlyg3ls34uPjUVlZCScnJ+jp6UFPTw/FxcV49913lXq6BbW3athqfy6YmJjAw8MDY8aMQXR0NPT09BAdHS1oTWxgq82px6wkWUjk5eUhNjZWVA9wFJsFCxZg+vTpHd57/vnnsWDBAixZskShbVB7q46N9udLW1sbGhsbhS5DbWy1OQXzM+rq6pCfny9/XVhYiNTUVFhaWsLe3h6vvPIKpFIpTp06hdbWVlRUVAAALC0tYWBgIFTZgumpvZycnDoFqb6+Puzs7ODt7d3r56m9e6du+/Ndk5WVFbZu3Yo5c+bA3t4eVVVV2LVrF8rKyjBv3jzOamITL23OxiUj2iQ2NpYB0Olr0aJFTGFhYZfLADCxsbFCly6IntqrK89eOkTtrR5125/vmh4/fsy89NJLjIODA2NgYMDY29szc+bMYa5fv85pTWzio81p2k9CCBEZOvlHCCEiQ8FMCCEiQ8FMCCEiQ8FMCCEiQ8FMCCEiQ8FMCCEiQ8FMCCEiQ8FMCCEiQ8Hcg8mTJ+Odd94Rugyl9fa4G01AbS8canvhUTDz6LvvvoNEIsGQIUM6LTt06BAkEgkrs3798ccfCAkJUXs7injy5AneeustWFlZoX///pg7dy7u3r3Ly76VoY1t/80332Dy5MkwMzODRCLBo0ePeNmvsrSt7R88eICVK1fC29sb/fr1g5OTE1atWoXq6mrW9kHBzDMTExNUVlbi2rVrHd6Pjo6Gk5MTK/uws7ODoaEhK9vqzerVq3Hy5EkcOnQIcXFxKC8vx8svv8zLvpWlbW3f0NCAWbNm4YMPPuBlf+rQprYvLy9HeXk5/vWvfyEzMxPfffcdzp49i2XLlrG2DwpmBT18+BALFy7EgAEDYGxsjJCQEOTl5XVY59tvv4WjoyOMjY3x0ksvISoqqtMjkPT09BAZGYk9e/bI37tz5w4uXbqEyMjIDutu2bIFQUFB2LNnD5ycnNC/f3/85S9/QWtrKz777DPY2dnBxsYGW7du7fC59n/SFRUVQSKRICYmBlOmTIGxsTECAwM7/YB0Z/LkyZBIJJ2+ioqKUF1djejoaERFRWHq1KkYMWIE9u7di99//x0JCQkKtmzvqO07tz0AvPPOO3j//fcxZswYhbanCmr7zm3v7++PI0eOIDw8HO7u7pg6dSq2bt2KkydPoqWlRcGW7RkFs4IWL16M5ORknDhxAteuXQPDMAgNDUVzczMA4OrVq1ixYgX++te/IjU1FTNmzOj0H0dm6dKlOHjwIBoaGgA8/VNv1qxZsLW17bRuQUEBzpw5g7Nnz+Lnn39GdHQ0wsLCcOfOHcTFxeHTTz/Fhg0ben38+4cffoi1a9ciNTUVXl5emD9/vkL/iWJiYvDHH3/Iv15++WV4e3vD1tYWKSkpaG5u7jD/rI+PD5ycnBT+AVAEtX3ntucLtb1ibV9dXQ0zMzPo6bE0k7Ja899puUmTJjF//etfmdzcXAYAc/XqVfmyqqoqpl+/fszBgwcZhmGYV199lQkLC+vw+ddff50xNzeXv967d6/8dVBQELNv3z6mra2NcXd3Z44fP85s376dcXZ2lq+/efNmxtjYmKmpqZG/9/zzzzMuLi5Ma2ur/D1vb29m27Zt8tdo9+Re2dSZ//nPf+TLb968yQBgsrKylGqPqKgoxsLCgsnJyWEYhmF+/PFHxsDAoNN6o0aNYv72t78pte1nUdt39GzbtyebhvLhw4dKbbM71PYd9dT2DMMw9+7dY5ycnJgPPvhAqe32hHrMCsjKyoKenh6Cg4Pl71lZWcHb2xtZWVkAgJycHIwePbrD55593d7SpUuxd+9exMXFob6+HqGhoV2u5+LiAlNTU/lrW1tb+Pr6QkdHp8N7lZWVPX4PQ4cOlf/b3t4eAHr9THtnzpzB+++/jwMHDsDLy0vhz6mL2p7aHhBv29fU1CAsLAy+vr7YsmWLwtvtDQWzQF5//XUkJCRgy5YtWLBgQbd/Aunr63d4LZFIunyvra2tx/21/4zsIZG9fUbm1q1beO211/DJJ59g5syZ8vft7OzQ1NTU6WqAu3fvws7OTqFtC0Eb2l5TaVPb19bWYtasWTA1NcXRo0c71acOCmYFDBkyBC0tLR3Gs+7fv4+cnBz4+voCALy9vZGUlNThc8++bs/S0hJz5sxBXFwcli5dyk3hLKiqqkJ4eDjmzp2L1atXd1g2YsQI6Ovr49dff5W/l5OTg5KSEowdO5aV/VPbd932fKC2777ta2pqMHPmTBgYGODEiRMwMjJidf8UzArw9PTECy+8gOXLl+PKlStIS0vDG2+8gUGDBuGFF14AAKxcuRKnT59GVFQU8vLy8PXXX+PMmTM9PsL8u+++Q1VVFXx8fPj6VpQ2d+5cGBsbY8uWLaioqJB/tba2wtzcHMuWLcOaNWsQGxuLlJQULFmyBGPHjmXtSgFq+67bHgAqKiqQmpoqf/5cRkYGUlNT8eDBA1b2T23fddvLQrm+vh7R0dGoqanpdGzURcGsoL1792LEiBGYPXs2xo4dC4ZhcPr0afmfL+PHj8fu3bsRFRWFwMBAnD17FqtXr+7xN2m/fv1E/9Tny5cvIzMzE87OzrC3t5d/lZaWAgC2b9+O2bNnY+7cuZg4cSLs7OwQExPDag3U9l23/e7duzFs2DAsX74cADBx4kQMGzYMJ06cYK0GavvObS+VSpGYmIiMjAx4eHh0eWzURc/849Dy5cuRnZ2N+Ph4oUvpc6jthUNtrz6WLrojAPCvf/0LM2bMgImJCc6cOYN9+/bhyy+/FLqsPoHaXjjU9hxg7cI7wsybN48ZOHAgY2RkxPj6+jJfffWV0CX1atasWYyJiUmXX1u3bhW6PIVR2wuH2p59NJTRx5WVleHx48ddLrO0tISlpSXPFfUd1PbCEXvbUzATQojI0FUZhBAiMhTMhBAiMhTMhBAiMhTMhBAiMhTMhBAiMhTMhBAiMhTMhBAiMv8fH6OzpbfiLVoAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 360x360 with 9 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "g = sns.pairplot(\n",
+    "    samples,\n",
+    "    vars=names[:3],\n",
+    "    kind='kde',\n",
+    "    plot_kws={\n",
+    "        'alpha': 0.5, 'levels': [0.05, 0.36, 1], 'fill': True,\n",
+    "        'common_norm': False, 'color': 'k'},\n",
+    "    diag_kws={'color': 'k', 'alpha': 0.1, 'fill': True},\n",
+    "    corner=True,\n",
+    "    height=1.2,\n",
+    ")\n",
+    "g.fig.subplots_adjust(wspace=0.15, hspace=0.15)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fc02ea59",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "logMmin_z0:\n",
+      "\t loc: 12.83843\n",
+      "\t scale: 0.24210\n",
+      "logMmin_z1:\n",
+      "\t loc: 13.05714\n",
+      "\t scale: 0.19465\n",
+      "logMmin_z2:\n",
+      "\t loc: 13.25134\n",
+      "\t scale: 0.13425\n"
+     ]
+    }
+   ],
+   "source": [
+    "for n in names[:3]:\n",
+    "    print(\n",
+    "        f'{n}:\\n\\t loc: {samples[n].mean():.5f}\\n\\t scale: {samples[n].std():.5f}')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Changes:

- You can now ask `cmass.bias.apply_hod` to use a smaller, preset HOD prior, which is typically constrained by fitting the empirical n(z).
- Adds a small line to clean up IC files after they're generated by PINOCCHIO
- Adds n(z) binning summary to lightcone summaries