### PR TITLE
Add `survey=simbig` option to hodlightcone

### DIFF
--- a/cmass/lightcone/lightcone.cpp
+++ b/cmass/lightcone/lightcone.cpp
@@ -67,15 +67,20 @@ namespace Geometry
                         { 1, 1, 0,
                           0, 0, 1,
                           1, 0, 0, },
+                        // 1.4142 1.0000 0.7071 (for SIMBIG)
+                        { 1, 1, 0,
+                          0, 0, 1,
+                          1, 0, 0, },
                       };
 
-    // get from the quadrant ra=[-90,90], dec=[0,90] to the NGC footprint
+    // get from the quadrant ra=[-90,90], dec=[0,90] to the obs footprint
     // we only need a rotation around the y-axis I believe
     const double alpha[] = {
         97.0 * M_PI / 180.0,  // NGC
         97.0 * M_PI / 180.0,  // NGC
         0,  // MTNG
         -30 * M_PI / 180.0,  // SGC
+        -5 * M_PI / 180.0,  // SIMBIG
     }; // rotation around y-axis
 
     const double beta[] = {
@@ -83,6 +88,7 @@ namespace Geometry
         6.0,  // NGC
         0,  // MTNG
         0,  // SGC
+        0,  // SIMBIG
     }; // rotation around z-axis, in degrees
 
     // in units of L1, L2, L3
@@ -91,6 +97,7 @@ namespace Geometry
         {0.5, -0.058, 0.0}, // NGC
         {0.0, 0.0, 0.0}, // MTNG
         {0.5, -0.058, 0.0}, // SGC
+        {0.45, 0.03, -1.15}, // SIMBIG
     };
 }
 

--- a/cmass/survey/hodlightcone.py
+++ b/cmass/survey/hodlightcone.py
@@ -81,6 +81,7 @@ def check_saturation(z, nz_dir, zmin, zmax, geometry):
     elif geometry == 'mtng':
         cap = 'MTNG'
     else:
+        return False  # SIMBIG hasn't been calculated yet
         raise ValueError(geometry)
 
     filepath = join(
@@ -127,6 +128,9 @@ def main(cfg: DictConfig) -> None:
     elif geometry == 'mtng':
         maskobs = None
         remap_case = 2
+    elif geometry == 'simbig':
+        maskobs = None
+        remap_case = 4
     else:
         raise ValueError(
             'Invalid geometry {geometry}. Choose from NGC, SGC, or MTNG.')
@@ -174,6 +178,8 @@ def main(cfg: DictConfig) -> None:
         outdir = join(source_path, 'sgc_lightcone')
     elif geometry == 'mtng':
         outdir = join(source_path, 'mtng_lightcone')
+    elif geometry == 'simbig':
+        outdir = join(source_path, 'simbig_lightcone')
     os.makedirs(outdir, exist_ok=True)
     save_lightcone(
         outdir,


### PR DESCRIPTION
This adds a SIMBIG-esque configuration to `cmass.survey.hodlightcone`. Previously, we simply generated a SGC lightcone with a 2 Gpc/h simulation, and then trimmed it down to the SIMBIG footprint with `cmass.survey.simbig_selection`.

These geometries allows us to position a 1 Gpc/h simulation exactly within the SIMBIG footprint.