### PR TITLE
Add options to generate survey randoms with hodlightcone

### DIFF
--- a/cmass/bias/apply_hod.py
+++ b/cmass/bias/apply_hod.py
@@ -153,8 +153,12 @@ def main(cfg: DictConfig) -> None:
     cfg = parse_hod(cfg)
     logging.info('Running with config:\n' + OmegaConf.to_yaml(cfg))
 
-    # Save with original hod_seed (parse_hod modifies it to lhid*1e6 + hod_seed)
-    hod_seed = int(cfg.bias.hod.seed - cfg.nbody.lhid * 1e6)
+    # Save with original hod_seed
+    if cfg.bias.hod.seed == 0:
+        hod_seed = cfg.bias.hod.seed
+    else:
+        # (parse_hod modifies it to lhid*1e6 + hod_seed)
+        hod_seed = int(cfg.bias.hod.seed - cfg.nbody.lhid * 1e6)
 
     # Setup save directory
     source_path = get_source_path(

--- a/cmass/bias/tools/hod.py
+++ b/cmass/bias/tools/hod.py
@@ -48,8 +48,8 @@ def lookup_hod_model(model=None, assem_bias=False, vel_assem_bias=False, zpivot=
 def parse_hod(cfg):
     """
     Parse HOD parameters in the config file, and set them
-    in the `cfg` object. 
-    TODO: IS THIS STILL NEEDED? 
+    in the `cfg` object.
+    TODO: IS THIS STILL NEEDED?
     MATT: It is, but there's probably a more elegant way to code this
 
     Args:

--- a/cmass/conf/survey/cmass_ngc.yaml
+++ b/cmass/conf/survey/cmass_ngc.yaml
@@ -23,3 +23,7 @@ mid_rdz: [184.83975076425324, 34.03863916513374, 0.4194598771198273]
 
 # For lightcone extrapolation
 boss_dir: "${meta.wdir}/obs/"  # path to observational masks
+
+
+# For randoms creation only (will not load any correct data!)
+randoms: False

--- a/cmass/conf/survey/cmass_sgc.yaml
+++ b/cmass/conf/survey/cmass_sgc.yaml
@@ -26,3 +26,7 @@ mid_rdz: [2.6749410426432902, 11.867070540112666, 0.48859496106951084]
 
 # For lightcone extrapolation
 boss_dir: "${meta.wdir}/obs/"  # path to observational masks
+
+
+# For randoms creation only (will not load any correct data!)
+randoms: False

--- a/cmass/conf/survey/default.yaml
+++ b/cmass/conf/survey/default.yaml
@@ -12,3 +12,6 @@ z_range: [0.4, 0.7]
 # For lightcone extrapolation
 boss_dir: "${meta.wdir}/obs/"  # path to observational masks
 fix_nz: False
+
+# For randoms creation only (will not load any correct data!)
+randoms: False

--- a/cmass/conf/survey/mtng.yaml
+++ b/cmass/conf/survey/mtng.yaml
@@ -27,3 +27,7 @@ z_range: [0.4, 0.7]
 
 # # For lightcone extrapolation (not used)
 # boss_dir: "${meta.wdir}/obs/"  # path to observational masks
+
+
+# For randoms creation only (will not load any correct data!)
+randoms: False

--- a/cmass/diagnostics/summ.py
+++ b/cmass/diagnostics/summ.py
@@ -517,8 +517,12 @@ def main(cfg: DictConfig) -> None:
     else:
         logging.info('Skipping halo diagnostics')
 
-    # Save with original hod_seed (parse_hod modifies it to lhid*1e6 + hod_seed)
-    hod_seed = int(cfg.bias.hod.seed - cfg.nbody.lhid * 1e6)
+    # Save with original hod_seed
+    if cfg.bias.hod.seed == 0:
+        hod_seed = cfg.bias.hod.seed
+    else:
+        # (parse_hod modifies it to lhid*1e6 + hod_seed)
+        hod_seed = int(cfg.bias.hod.seed - cfg.nbody.lhid * 1e6)
 
     # measure galaxy diagnostics
     if cfg.diag.all or cfg.diag.galaxy:

--- a/cmass/survey/hodlightcone.py
+++ b/cmass/survey/hodlightcone.py
@@ -143,7 +143,7 @@ def main(cfg: DictConfig) -> None:
     # throw a big warning if we're generating randoms
     if cfg.survey.randoms:
         logging.warning(
-            'Generating uniform randoms. This is not for generating training '
+            'Generating uniform randoms. This is not for generating '
             'training data, but for generating randoms for the lightcone. '
         )
 

--- a/cmass/survey/hodlightcone.py
+++ b/cmass/survey/hodlightcone.py
@@ -126,8 +126,12 @@ def main(cfg: DictConfig) -> None:
         cfg.meta.wdir, cfg.nbody.suite, cfg.sim,
         cfg.nbody.L, cfg.nbody.N, cfg.nbody.lhid
     )
-    # Save with original hod_seed (parse_hod modifies it to lhid*1e6 + hod_seed)
-    hod_seed = int(cfg.bias.hod.seed - cfg.nbody.lhid * 1e6)
+    # Save with original hod_seed
+    if cfg.bias.hod.seed == 0:
+        hod_seed = cfg.bias.hod.seed
+    else:
+        # (parse_hod modifies it to lhid*1e6 + hod_seed)
+        hod_seed = int(cfg.bias.hod.seed - cfg.nbody.lhid * 1e6)
     aug_seed = cfg.survey.aug_seed  # for rotating and shuffling
 
     geometry = cfg.survey.geometry  # whether to use NGC, SGC, or MTNG mask

--- a/cmass/survey/hodtools.py
+++ b/cmass/survey/hodtools.py
@@ -50,7 +50,8 @@ def randoms_engine(snap_idx, hlo_idx, z):
     A dummy engine for randoms, which returns 0 dpos, dvel, and the basic
     host id
     """
-    dgpos = np.zeros((len(hlo_idx), 3))
-    dgvel = np.zeros((len(hlo_idx), 3))
-    ghost = hlo_idx
+    print(f'Generating randoms for snap_idx={snap_idx}')
+    dgpos = np.zeros((len(hlo_idx), 3)).astype(np.float64)
+    dgvel = np.zeros((len(hlo_idx), 3)).astype(np.float64)
+    ghost = np.arange(len(hlo_idx), dtype=np.uint64)
     return ghost, dgpos, dgvel

--- a/cmass/survey/hodtools.py
+++ b/cmass/survey/hodtools.py
@@ -21,7 +21,6 @@ class HODEngine():
         # difference between the galaxy's position and that of the host halo,
         # so the noise will cancel out.
         hpos, hvel, hmass, hmeta = load_snapshot(self.simdir, a)
-        print('loaded')
 
         # Only keep those selected for the lightcone
         hpos = hpos[hlo_idx]
@@ -44,3 +43,14 @@ class HODEngine():
         dgvel = dgvel.astype(np.float64)
 
         return ghost, dgpos, dgvel
+
+
+def randoms_engine(snap_idx, hlo_idx, z):
+    """
+    A dummy engine for randoms, which returns 0 dpos, dvel, and the basic
+    host id
+    """
+    dgpos = np.zeros((len(hlo_idx), 3))
+    dgvel = np.zeros((len(hlo_idx), 3))
+    ghost = hlo_idx
+    return ghost, dgpos, dgvel

--- a/jobs/run_randoms.sh
+++ b/jobs/run_randoms.sh
@@ -8,31 +8,30 @@ conda activate cmassrun
 # Command to run for each lhid
 cd /home/x-mho1/git/ltu-cmass-run
 
-# Nhod=5
 
-# echo "~~~ GENERATE SIMBIG RANDOMS ~~~"
+echo "~~~ GENERATE SIMBIG RANDOMS ~~~"
 
-# nbody=quijote
-# sim=randoms
-# noise_uniform_invoxel=False  # whether to uniformly distribute galaxies in each voxel (for CHARM only)
-# noise=fixed
-# diag_from_scratch=True
-# extras="survey.randoms=True"
+nbody=quijote
+sim=randoms
+noise_uniform_invoxel=False  # whether to uniformly distribute galaxies in each voxel (for CHARM only)
+noise=fixed
+diag_from_scratch=True
+extras="survey.randoms=True"
 
-# L=1000
-# N=128
-# lhid=2
-# hod_seed=0
-# aug_seed=0
+L=1000
+N=128
+lhid=2
+hod_seed=1
+aug_seed=0
 
-# postfix="nbody=$nbody sim=$sim nbody.lhid=$lhid"
-# postfix="$postfix bias.hod.seed=$hod_seed survey.aug_seed=$aug_seed"
-# postfix="$postfix diag.from_scratch=$diag_from_scratch"
-# postfix="$postfix bias.hod.noise_uniform=$noise_uniform_invoxel"
-# postfix="$postfix noise=$noise"
-# postfix="$postfix $extras"
+postfix="nbody=$nbody sim=$sim nbody.lhid=$lhid"
+postfix="$postfix bias.hod.seed=$hod_seed survey.aug_seed=$aug_seed"
+postfix="$postfix diag.from_scratch=$diag_from_scratch"
+postfix="$postfix bias.hod.noise_uniform=$noise_uniform_invoxel"
+postfix="$postfix noise=$noise"
+postfix="$postfix $extras"
 
-# python -m cmass.survey.hodlightcone survey.geometry=simbig $postfix bias.hod.seed=$hod_seed survey.aug_seed=$aug_seed
+python -m cmass.survey.hodlightcone survey.geometry=simbig $postfix bias.hod.seed=$hod_seed survey.aug_seed=$aug_seed
 
 
 
@@ -88,26 +87,26 @@ cd /home/x-mho1/git/ltu-cmass-run
 
 
 
-echo "~~~ GENERATE NGC RANDOMS ~~~"
+# echo "~~~ GENERATE NGC RANDOMS ~~~"
 
-nbody=quijote3gpch
-sim=randoms
-noise_uniform_invoxel=False  # whether to uniformly distribute galaxies in each voxel (for CHARM only)
-noise=fixed
-diag_from_scratch=True
-extras="survey.randoms=True"
+# nbody=quijote3gpch
+# sim=randoms
+# noise_uniform_invoxel=False  # whether to uniformly distribute galaxies in each voxel (for CHARM only)
+# noise=fixed
+# diag_from_scratch=True
+# extras="survey.randoms=True"
 
-L=3000
-N=384
-lhid=2000
-hod_seed=0
-aug_seed=0
+# L=3000
+# N=384
+# lhid=2000
+# hod_seed=0
+# aug_seed=0
 
-postfix="nbody=$nbody sim=$sim nbody.lhid=$lhid"
-postfix="$postfix bias.hod.seed=$hod_seed survey.aug_seed=$aug_seed"
-postfix="$postfix diag.from_scratch=$diag_from_scratch"
-postfix="$postfix bias.hod.noise_uniform=$noise_uniform_invoxel"
-postfix="$postfix noise=$noise"
-postfix="$postfix $extras"
+# postfix="nbody=$nbody sim=$sim nbody.lhid=$lhid"
+# postfix="$postfix bias.hod.seed=$hod_seed survey.aug_seed=$aug_seed"
+# postfix="$postfix diag.from_scratch=$diag_from_scratch"
+# postfix="$postfix bias.hod.noise_uniform=$noise_uniform_invoxel"
+# postfix="$postfix noise=$noise"
+# postfix="$postfix $extras"
 
-python -m cmass.survey.hodlightcone survey.geometry=ngc $postfix bias.hod.seed=$hod_seed survey.aug_seed=$aug_seed
+# python -m cmass.survey.hodlightcone survey.geometry=ngc $postfix bias.hod.seed=$hod_seed survey.aug_seed=$aug_seed

--- a/jobs/run_randoms.sh
+++ b/jobs/run_randoms.sh
@@ -2,53 +2,26 @@
 set -e
 
 module restore cmass
-conda activate cmass
+conda activate cmassrun
 
 
 # Command to run for each lhid
-cd /jet/home/mho1/git/ltu-cmass
+cd /home/x-mho1/git/ltu-cmass-run
 
 # Nhod=5
 
-echo "~~~ GENERATE SIMBIG RANDOMS ~~~"
+# echo "~~~ GENERATE SIMBIG RANDOMS ~~~"
 
-nbody=quijote
-sim=randoms
-noise_uniform_invoxel=False  # whether to uniformly distribute galaxies in each voxel (for CHARM only)
-noise=fixed
-diag_from_scratch=True
-extras="survey.randoms=True"
-
-L=1000
-N=128
-lhid=0
-hod_seed=0
-aug_seed=0
-
-postfix="nbody=$nbody sim=$sim nbody.lhid=$lhid"
-postfix="$postfix bias.hod.seed=$hod_seed survey.aug_seed=$aug_seed"
-postfix="$postfix diag.from_scratch=$diag_from_scratch"
-postfix="$postfix bias.hod.noise_uniform=$noise_uniform_invoxel"
-postfix="$postfix noise=$noise"
-postfix="$postfix $extras"
-
-python -m cmass.survey.hodlightcone survey.geometry=simbig $postfix bias.hod.seed=$hod_seed survey.aug_seed=$aug_seed
-
-
-
-
-# echo "~~~ GENERATE NGC RANDOMS ~~~"
-
-# nbody=quijote3gpch
+# nbody=quijote
 # sim=randoms
 # noise_uniform_invoxel=False  # whether to uniformly distribute galaxies in each voxel (for CHARM only)
 # noise=fixed
 # diag_from_scratch=True
-# extras="survey.randoms=True noise.params.radial=4 noise.params.transverse=4"
+# extras="survey.randoms=True"
 
-# L=3000
-# N=384
-# lhid=2000
+# L=1000
+# N=128
+# lhid=2
 # hod_seed=0
 # aug_seed=0
 
@@ -59,4 +32,82 @@ python -m cmass.survey.hodlightcone survey.geometry=simbig $postfix bias.hod.see
 # postfix="$postfix noise=$noise"
 # postfix="$postfix $extras"
 
-# python -m cmass.survey.hodlightcone survey.geometry=ngc $postfix bias.hod.seed=$hod_seed survey.aug_seed=$aug_seed
+# python -m cmass.survey.hodlightcone survey.geometry=simbig $postfix bias.hod.seed=$hod_seed survey.aug_seed=$aug_seed
+
+
+
+# echo "~~~ GENERATE SGC RANDOMS ~~~"
+
+# nbody=abacus
+# sim=randoms
+# noise_uniform_invoxel=False  # whether to uniformly distribute galaxies in each voxel (for CHARM only)
+# noise=fixed
+# diag_from_scratch=True
+# extras="survey.randoms=True"
+
+# L=2000
+# N=256
+# lhid=3
+# hod_seed=0
+# aug_seed=0
+
+# postfix="nbody=$nbody sim=$sim nbody.lhid=$lhid"
+# postfix="$postfix bias.hod.seed=$hod_seed survey.aug_seed=$aug_seed"
+# postfix="$postfix diag.from_scratch=$diag_from_scratch"
+# postfix="$postfix bias.hod.noise_uniform=$noise_uniform_invoxel"
+# postfix="$postfix noise=$noise"
+# postfix="$postfix $extras"
+
+# python -m cmass.survey.hodlightcone survey.geometry=sgc $postfix bias.hod.seed=$hod_seed survey.aug_seed=$aug_seed
+
+
+
+# echo "~~~ GENERATE MTNG RANDOMS ~~~"
+
+# nbody=abacus
+# sim=randoms
+# noise_uniform_invoxel=False  # whether to uniformly distribute galaxies in each voxel (for CHARM only)
+# noise=fixed
+# diag_from_scratch=True
+# extras="survey.randoms=True"
+
+# L=2000
+# N=256
+# lhid=0
+# hod_seed=0
+# aug_seed=0
+
+# postfix="nbody=$nbody sim=$sim nbody.lhid=$lhid"
+# postfix="$postfix bias.hod.seed=$hod_seed survey.aug_seed=$aug_seed"
+# postfix="$postfix diag.from_scratch=$diag_from_scratch"
+# postfix="$postfix bias.hod.noise_uniform=$noise_uniform_invoxel"
+# postfix="$postfix noise=$noise"
+# postfix="$postfix $extras"
+
+# python -m cmass.survey.hodlightcone survey.geometry=mtng $postfix bias.hod.seed=$hod_seed survey.aug_seed=$aug_seed
+
+
+
+echo "~~~ GENERATE NGC RANDOMS ~~~"
+
+nbody=quijote3gpch
+sim=randoms
+noise_uniform_invoxel=False  # whether to uniformly distribute galaxies in each voxel (for CHARM only)
+noise=fixed
+diag_from_scratch=True
+extras="survey.randoms=True"
+
+L=3000
+N=384
+lhid=2000
+hod_seed=0
+aug_seed=0
+
+postfix="nbody=$nbody sim=$sim nbody.lhid=$lhid"
+postfix="$postfix bias.hod.seed=$hod_seed survey.aug_seed=$aug_seed"
+postfix="$postfix diag.from_scratch=$diag_from_scratch"
+postfix="$postfix bias.hod.noise_uniform=$noise_uniform_invoxel"
+postfix="$postfix noise=$noise"
+postfix="$postfix $extras"
+
+python -m cmass.survey.hodlightcone survey.geometry=ngc $postfix bias.hod.seed=$hod_seed survey.aug_seed=$aug_seed

--- a/jobs/run_randoms.sh
+++ b/jobs/run_randoms.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -e
+
+module restore cmass
+conda activate cmass
+
+
+# Command to run for each lhid
+cd /jet/home/mho1/git/ltu-cmass
+
+# Nhod=5
+
+echo "~~~ GENERATE SIMBIG RANDOMS ~~~"
+
+nbody=quijote
+sim=randoms
+noise_uniform_invoxel=False  # whether to uniformly distribute galaxies in each voxel (for CHARM only)
+noise=fixed
+diag_from_scratch=True
+extras="survey.randoms=True"
+
+L=1000
+N=128
+lhid=0
+hod_seed=0
+aug_seed=0
+
+postfix="nbody=$nbody sim=$sim nbody.lhid=$lhid"
+postfix="$postfix bias.hod.seed=$hod_seed survey.aug_seed=$aug_seed"
+postfix="$postfix diag.from_scratch=$diag_from_scratch"
+postfix="$postfix bias.hod.noise_uniform=$noise_uniform_invoxel"
+postfix="$postfix noise=$noise"
+postfix="$postfix $extras"
+
+python -m cmass.survey.hodlightcone survey.geometry=simbig $postfix bias.hod.seed=$hod_seed survey.aug_seed=$aug_seed
+
+
+
+
+# echo "~~~ GENERATE NGC RANDOMS ~~~"
+
+# nbody=quijote3gpch
+# sim=randoms
+# noise_uniform_invoxel=False  # whether to uniformly distribute galaxies in each voxel (for CHARM only)
+# noise=fixed
+# diag_from_scratch=True
+# extras="survey.randoms=True noise.params.radial=4 noise.params.transverse=4"
+
+# L=3000
+# N=384
+# lhid=2000
+# hod_seed=0
+# aug_seed=0
+
+# postfix="nbody=$nbody sim=$sim nbody.lhid=$lhid"
+# postfix="$postfix bias.hod.seed=$hod_seed survey.aug_seed=$aug_seed"
+# postfix="$postfix diag.from_scratch=$diag_from_scratch"
+# postfix="$postfix bias.hod.noise_uniform=$noise_uniform_invoxel"
+# postfix="$postfix noise=$noise"
+# postfix="$postfix $extras"
+
+# python -m cmass.survey.hodlightcone survey.geometry=ngc $postfix bias.hod.seed=$hod_seed survey.aug_seed=$aug_seed


### PR DESCRIPTION
Adds ability to construct survey random catalogs with `cmass.survey.hodlightcone`. When `survey.randoms=True`, this generates a Uniform field of galaxies with number density `3e-4` (Mpc/h)^-3, roughly the number density of CMASS. Turning on this randoms mode does not load any halo information from disk.

This is helpful for estimating survey volume and for ensuring the survey footprints are covered.

EDIT: This also includes a small bugfix for the hod naming convention for when hod_seed=0