### PR TITLE
Adding radial/transverse noise to lightcone construction, instead of in diagnostics

### DIFF
--- a/cmass/bias/tools/hod.py
+++ b/cmass/bias/tools/hod.py
@@ -143,6 +143,28 @@ def parse_hod(cfg):
     return cfg
 
 
+def parse_noise(
+    seed, dist, params
+):
+    np.random.seed(seed)
+    if dist == 'Fixed':
+        radial, transverse = params['radial'], params['transverse']
+    elif dist == 'Uniform':
+        a = params['a']
+        b = params['b']
+        radial, transverse = np.random.uniform(a, b, size=2)
+    elif dist == 'Reciprocal':
+        a = np.log(params['a'])
+        b = np.log(params['b'])
+        radial, transverse = np.exp(np.random.uniform(a, b, size=2))
+    elif dist == 'Exponential':
+        scale = params['scale']
+        radial, transverse = np.random.exponential(scale, size=2)
+    else:
+        raise NotImplementedError(f'Noise distribution {dist} not implemented')
+    return float(radial), float(transverse)
+
+
 def build_HOD_model(
     cosmology,
     model,

--- a/cmass/diagnostics/pypower.py
+++ b/cmass/diagnostics/pypower.py
@@ -88,8 +88,6 @@ def main():
     parser.add_argument('--use-fkp', action='store_true')
     parser.add_argument('--high-res', action='store_true')
     parser.add_argument('--resampler', type=str, default='tsc')
-    parser.add_argument('--noise-radial', type=float, default=0.0)
-    parser.add_argument('--noise-transverse', type=float, default=0.0)
     args = parser.parse_args()
 
     interlacing = 2

--- a/cmass/diagnostics/pypower.py
+++ b/cmass/diagnostics/pypower.py
@@ -9,7 +9,7 @@ from astropy import units as u
 from astropy.stats import scott_bin_width
 from scipy.interpolate import InterpolatedUnivariateSpline
 
-from .tools import noise_positions, save_group
+from .tools import save_group
 from .geometry import SURVEY_GEOMETRIES
 from ..survey.tools import sky_to_xyz
 
@@ -42,21 +42,11 @@ def get_nofz(z, fsky, cosmo):
 
 
 def preprocess_lightcone_catalogs(
-        data_rdz, randoms_rdz,
-        noise_radial, noise_transverse):
+        data_rdz, randoms_rdz):
     """Loads, transforms, and prepares data and randoms catalogs."""
     # Convert to comoving coordinates
     data_pos = sky_to_xyz(data_rdz, cosmo)
     randoms_pos = sky_to_xyz(randoms_rdz, cosmo)
-
-    # Add observational noise (TODO: move to hodlightcone.py)
-    if noise_radial > 0 or noise_transverse > 0:
-        data_pos = noise_positions(
-            data_pos, data_rdz[:, 0], data_rdz[:, 1],
-            noise_radial, noise_transverse)
-        randoms_pos = noise_positions(
-            randoms_pos, randoms_rdz[:, 0], randoms_rdz[:, 1],
-            noise_radial, noise_transverse)
 
     # Final type casting
     data_pos = data_pos.astype(np.float32)
@@ -144,8 +134,7 @@ def main():
     if rank == 0:
         # TODO: Cache randoms?
         data_pos, randoms_pos = preprocess_lightcone_catalogs(
-            data_rdz, randoms_rdz,
-            args.noise_radial, args.noise_transverse
+            data_rdz, randoms_rdz
         )
         if args.use_fkp:
             data_weights, nofz = compute_fkp_weights(
@@ -233,8 +222,6 @@ def main():
     out_attrs['log10nbar'] = \
         np.log10(Ngalaxies) - 3 * np.log10(boxsize)
     out_attrs['high_res'] = args.high_res and args.resampler == 'tsc'
-    out_attrs['noise_radial'] = args.noise_radial
-    out_attrs['noise_transverse'] = args.noise_transverse
 
     # Save n(z)
     zbins = np.linspace(0.4, 0.7, 101)  # spacing in dz = 0.003

--- a/cmass/diagnostics/summ.py
+++ b/cmass/diagnostics/summ.py
@@ -11,7 +11,6 @@ import hydra
 from omegaconf import DictConfig, OmegaConf
 import h5py
 from astropy.cosmology import Planck18
-from scipy.spatial.transform import Rotation as R
 import subprocess
 
 from ..utils import (
@@ -19,10 +18,10 @@ from ..utils import (
     save_configuration_h5
 )
 from ..nbody.tools import parse_nbody_config
-from ..bias.apply_hod import parse_hod
+from ..bias.tools.hod import parse_hod, parse_noise
 from .tools import (
     get_mesh_resolution, noise_positions, store_summary, check_existing,
-    parse_noise, _get_snapshot_alist, save_group
+    _get_snapshot_alist, save_group
 )
 from .calculations import (
     MA, MAz, calcPk, calcBk_bfast,

--- a/cmass/diagnostics/summ.py
+++ b/cmass/diagnostics/summ.py
@@ -347,6 +347,9 @@ def summarize_lightcone_pylians(
     pos = pos - geom['boxcenter'] + 0.5 * geom['boxsize']
     L = geom['boxsize']
 
+    # Convert to float32
+    pos = pos.astype(np.float32)
+
     # Check if all tracers are inside the box
     if np.any(pos < 0) or np.any(pos > L):
         logging.error('Error! Some tracers outside of box!')

--- a/cmass/diagnostics/tools.py
+++ b/cmass/diagnostics/tools.py
@@ -113,7 +113,8 @@ def noise_positions(pos, ra, dec,
     return pos
 
 
-def save_group(file, data, attrs=None, a=None, config=None, save_HOD=False):
+def save_group(file, data, attrs=None, a=None, config=None,
+               save_HOD=False, save_noise=False):
     logging.info(f'Saving {len(data)} datasets to {file}')
     with h5py.File(file, 'a') as f:
         if a is not None:
@@ -130,7 +131,8 @@ def save_group(file, data, attrs=None, a=None, config=None, save_HOD=False):
             group.create_dataset(key, data=value)
 
         if config is not None:
-            save_configuration_h5(f, config, save_HOD=save_HOD)
+            save_configuration_h5(
+                f, config, save_HOD=save_HOD, save_noise=save_noise)
 
 
 # Summarizer functions

--- a/cmass/diagnostics/tools.py
+++ b/cmass/diagnostics/tools.py
@@ -102,28 +102,6 @@ def get_mesh_resolution(L, high_res=False, use_ngp=False):
     return N, MAS
 
 
-def parse_noise(
-    seed, dist, params
-):
-    np.random.seed(seed)
-    if dist == 'Fixed':
-        radial, transverse = params['radial'], params['transverse']
-    elif dist == 'Uniform':
-        a = params['a']
-        b = params['b']
-        radial, transverse = np.random.uniform(a, b, size=2)
-    elif dist == 'Reciprocal':
-        a = np.log(params['a'])
-        b = np.log(params['b'])
-        radial, transverse = np.exp(np.random.uniform(a, b, size=2))
-    elif dist == 'Exponential':
-        scale = params['scale']
-        radial, transverse = np.random.exponential(scale, size=2)
-    else:
-        raise NotImplementedError(f'Noise distribution {dist} not implemented')
-    return float(radial), float(transverse)
-
-
 def noise_positions(pos, ra, dec,
                     noise_radial, noise_transverse):
     """Applies observational noise to positions."""

--- a/cmass/lightcone/lightcone.cpp
+++ b/cmass/lightcone/lightcone.cpp
@@ -618,7 +618,9 @@ void Lightcone::choose_halos (int snap_idx, size_t Nhlo,
         scaled_offset[kk] *= scale_factor;
     }
 
-    std::printf("sigmaradial: %.6f, sigmatransverse: %.6f\n", sigmaradial, sigmatransverse);
+    if (verbose) {
+        std::printf("sigmaradial: %.6f, sigmatransverse: %.6f\n", sigmaradial, sigmatransverse);
+    }
     #pragma omp parallel
     {
         // the accelerator is non-const upon evaluation

--- a/cmass/survey/hodlightcone.py
+++ b/cmass/survey/hodlightcone.py
@@ -214,7 +214,7 @@ def main(cfg: DictConfig) -> None:
         zmax=zmax,
         zmid=zmid,  # to set the offset of the simulation box
         snap_times=snap_times,
-        verbose=True,
+        verbose=False,
         augment=aug_seed,
         remap_case=remap_case,
         sigmaradial=cfg.noise.radial,

--- a/cmass/survey/hodlightcone.py
+++ b/cmass/survey/hodlightcone.py
@@ -40,7 +40,7 @@ from ..nbody.tools import parse_nbody_config
 from .tools import save_lightcone, in_simbig_selection
 from .hodtools import HODEngine, randoms_engine
 from ..bias.apply_hod import load_snapshot
-from ..bias.tools.hod import parse_hod
+from ..bias.tools.hod import parse_hod, parse_noise
 
 try:
     from ..lightcone import lc
@@ -117,11 +117,19 @@ def check_saturation(z, nz_dir, zmin, zmax, geometry):
 def main(cfg: DictConfig) -> None:
     # Filtering for necessary configs
     cfg = OmegaConf.masked_copy(
-        cfg, ['meta', 'sim', 'multisnapshot', 'nbody', 'bias', 'survey'])
+        cfg, ['meta', 'sim', 'multisnapshot', 'nbody', 'bias',
+              'survey', 'noise'])
 
     # Build run config
     cfg = parse_nbody_config(cfg)
     cfg = parse_hod(cfg)
+    # parse noise (seeded by lhid and hod seed)  (TODO: make take less lines)
+    noise_seed = int(cfg.nbody.lhid*1e4 + cfg.bias.hod.seed)
+    cfg.noise.radial, cfg.noise.transverse = \
+        parse_noise(seed=noise_seed,
+                    dist=cfg.noise.dist,
+                    params=cfg.noise.params)
+
     logging.info('Running with config:\n' + OmegaConf.to_yaml(cfg))
     source_path = get_source_path(
         cfg.meta.wdir, cfg.nbody.suite, cfg.sim,
@@ -209,6 +217,8 @@ def main(cfg: DictConfig) -> None:
         verbose=True,
         augment=aug_seed,
         remap_case=remap_case,
+        sigmaradial=cfg.noise.radial,
+        sigmatransverse=cfg.noise.transverse,
         seed=42,
         is_north=geometry == 'ngc'
     )
@@ -263,7 +273,9 @@ def main(cfg: DictConfig) -> None:
         hod_seed=hod_seed,
         aug_seed=aug_seed,
         saturated=saturated,
-        config=cfg
+        config=cfg,
+        noise_radial=cfg.noise.radial,
+        noise_transverse=cfg.noise.transverse
     )
     save_cfg(source_path, cfg, field='survey')
 

--- a/cmass/utils/utils.py
+++ b/cmass/utils/utils.py
@@ -130,7 +130,7 @@ def cosmo_to_colossus(cpars):
     return cosmo
 
 
-def save_configuration_h5(file, config, save_HOD=True):
+def save_configuration_h5(file, config, save_HOD=True, save_noise=False):
     file.attrs['config'] = OmegaConf.to_yaml(config)
     file.attrs['cosmo_names'] = ['Omega_m', 'Omega_b', 'h', 'n_s', 'sigma8']
     file.attrs['cosmo_params'] = config.nbody.cosmo
@@ -142,3 +142,7 @@ def save_configuration_h5(file, config, save_HOD=True):
         keys = sorted(list(config.bias.hod.theta.keys()))
         file.attrs['HOD_names'] = keys
         file.attrs['HOD_params'] = [config.bias.hod.theta[k] for k in keys]
+    if save_noise:
+        file.attrs['noise_dist'] = config.noise.dist
+        file.attrs['noise_radial'] = config.noise.radial
+        file.attrs['noise_transverse'] = config.noise.transverse


### PR DESCRIPTION
This has advantages:
* Our previous approach of adding noise after lightcone construction(during diagnostics) would 'fuzz' the edges of our footprint.
* Our simulation and observed data would need different noise scales, which would mean these edges would be misspecified in the comparison
* We had to noise our Randoms catalogs for every noise scale (to match these edges), but now we can just leave them fixed. We can set radial/transverse noise of the randoms to 0 since they are just a continuous, constant Gaussian random field anyway.